### PR TITLE
Update broken image URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
 # Steve's Jujutsu tutorial
 
 [Read it here](https://steveklabnik.github.io/jujutsu-tutorial/).
+
+## Requirements
+
+Building the book requires [mdBook]. To get it:
+
+[mdBook]: https://github.com/rust-lang/mdBook
+
+```bash
+$ cargo install mdbook
+```
+
+Or you can also install via Homebrew:
+
+```bash
+$ brew install mdbook
+```
+
+## Building
+
+To build the book, type:
+
+```bash
+$ mdbook build
+```
+
+The output will be in the `book` subdirectory. To check it out, open it in
+your web browser.
+
+_Firefox:_
+```bash
+$ firefox book/index.html                       # Linux
+$ open -a "Firefox" book/index.html             # OS X
+$ Start-Process "firefox.exe" .\book\index.html # Windows (PowerShell)
+$ start firefox.exe .\book\index.html           # Windows (Cmd)
+```
+
+_Chrome:_
+```bash
+$ google-chrome book/index.html                 # Linux
+$ open -a "Google Chrome" book/index.html       # OS X
+$ Start-Process "chrome.exe" .\book\index.html  # Windows (PowerShell)
+$ start chrome.exe .\book\index.html            # Windows (Cmd)
+```

--- a/src/branching-merging-and-conflicts/anonymous-branches.md
+++ b/src/branching-merging-and-conflicts/anonymous-branches.md
@@ -11,7 +11,7 @@ branches once they get used to things.
 
 Let's talk about it.
 
-## What is a branch, conceptualy?
+## What is a branch, conceptually?
 
 When two changes share the same parent change, we say that they are "branching,"
 because the graph of commits would look like this:

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -68,6 +68,4 @@ than as I work. That is, the branch name tends to sit at the same change as the
 remote server, and when it's time to update the remote, that's when I update
 things locally.
 
-`jj` will update the branch when changes get 
-
 Speaking of remotes, let's talk about that next.

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -55,7 +55,7 @@ Branch changes to push to origin:
 
 And now our project is up on GitHub!
 
-![new project on github](/images/github-create.png)
+![new project on github](../images/github-create.png)
 
 Now we can push our branch up to GitHub:
 
@@ -69,7 +69,7 @@ If you collaborate on a project, as commits land on the main branch, you'll want
 to update your local copy of that branch. I'm going to make a change in the
 GitHub UI:
 
-![creating a commit on github](/images/github-commit.png)
+![creating a commit on github](../images/github-commit.png)
 
 All I did was update the `Cargo.toml` to remove some comments. If you're
 following along, you can make any change you'd like.
@@ -156,7 +156,7 @@ any unique prefix works: `vmunwxsk` is just as much a unique prefix of
 
 We can now make a pull request out of this:
 
-![github showing us we have a branch with recent pushes](/images/new-branch.png)
+![github showing us we have a branch with recent pushes](../images/new-branch.png)
 
 If you'd like to view this PR, you can find it
 [here](https://github.com/steveklabnik/jj-hello-world/pull/1), though by the

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -2,7 +2,7 @@
 
 Oh no! Someone has asked for changes to our pull request.
 
-![a screenshot of me commenting on my github PR](/images/pr-feedback.png)
+![a screenshot of me commenting on my github PR](../images/pr-feedback.png)
 
 We have two ways of making our change, and it depends on what the project's
 maintainers prefer. Due to the way that GitHub shows or minimizes comments on
@@ -73,7 +73,7 @@ Branch changes to push to origin:
   Move branch push-vmunwxsksqvk from 9410db49f9ba to ad6b9b149f88
 ```
 
-![a screenshot of github, showing the new commit below our review](/images/new-pr-commit.png)
+![a screenshot of github, showing the new commit below our review](../images/new-pr-commit.png)
 
 Since we added a commit, the review comment is still there, which is why people
 like this workflow.
@@ -172,7 +172,7 @@ Branch changes to push to origin:
 
 We can see that reflected on GitHub:
 
-![a screenshot of github showing that our branch was force pushed](/images/force-push-pr.png)
+![a screenshot of github showing that our branch was force pushed](../images/force-push-pr.png)
 
 Only one commit, and it shows that our comment is on an outdated commit.
 


### PR DESCRIPTION
This PR fixes relative image URLs that were broken.

It also adds a simple README, mostly stolen from the Rust book README so other people don't have to go spelunking in the .github actions yaml file to figure out how it's built. :)

Also a couple of very minor typos / unfinished things.