### PR TITLE
Replace branch with bookmark

### DIFF
--- a/src/branching-merging-and-conflicts/revsets.md
+++ b/src/branching-merging-and-conflicts/revsets.md
@@ -84,7 +84,7 @@ Additionally, on the `jj` Discord, several folks have settled on this as a
 decent revset for larger repositories:
 
 ```console
-$ jj log -r '@ | ancestors(remote_branches().., 2) | trunk()'
+$ jj log -r '@ | ancestors(remote_bookmarks().., 2) | trunk()'
 ```
 
 This will show the history from the working directory, some detail about remote

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -1,15 +1,15 @@
 # Using named branches in `jj`
 
-Named branches are mostly an interoperability feature in `jj`; other than some
+Named branches (or, starting with `jj 0.22`, "bookmarks") are mostly an interoperability feature in `jj`; other than some
 sort of "main branch" that indicates where shared history lives, other branches
 aren't neccesary to get work done. However, if you use a tool like GitHub, which
 bases a lot of its functionality around `git` branches, then you'll end up using
 more than one named branch.
 
-To create a named branch in `jj`, we can use `jj branch create`:
+To create a named branch (bookmark) in `jj`, we can use `jj bookmark create`:
 
 ```console
-$ jj branch create trunk
+$ jj bookmark create trunk
 $ jj log --limit 2
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
 │  remove goodbye message
@@ -70,7 +70,8 @@ behavior is a bit surprising for folks coming from `git`, though it fits in with
 Regardless, let's update `trunk` to point at `@`:
 
 ```console
-$ jj branch set trunk
+$ jj bookmark set trunk
+Moved 1 bookmarks to pzkrzopz fcf669c5 trunk | (empty) (no description set)
 $ jj log --limit 2
 @  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 trunk fcf669c5
 │  (empty) (no description set)

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -30,7 +30,8 @@ do that like this:
 $ jj edit @-
 Working copy now at: povouosx f68d1623 remove goodbye message
 Parent commit      : vvmrvwuz d41c079b refactor printing
-$ jj branch set trunk --allow-backwards
+$ jj bookmark set trunk --allow-backwards
+Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
 $ jj abandon pzkrzopz
 Abandoned commit pzkrzopz fcf669c5 (empty) (no description set)
 $ jj log --limit 2
@@ -49,8 +50,11 @@ Anyway, let's push `trunk` up to GitHub:
 
 ```console
 $ jj git push
-Branch changes to push to origin:
-  Add branch trunk to f68d16233bdc
+Changes to push to origin:
+  Add bookmark trunk to f68d16233bdc
+Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
+Working copy now at: znurnwmk f853107d (empty) (no description set)
+Parent commit      : povouosx f68d1623 | remove goodbye message
 ```
 
 And now our project is up on GitHub!
@@ -73,9 +77,12 @@ Let's fetch those changes:
 
 ```console
 $ jj git fetch
+bookmark: trunk@origin [updated] tracked
 $ jj log --limit 3
 ◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
 │  Update Cargo.toml
+│ @  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00.000 f853107d
+├─╯  (empty) (no description set)
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
 │  remove goodbye message
 ~
@@ -83,7 +90,7 @@ $ jj log --limit 3
 
 In this instance, `trunk` did move to the new commit: we asked `jj` to fetch
 information from our origin, and so it's adjusted things to match. However, `@`
-is still at our current commit.
+is still at our current commit (ie. the empty commit created by `jj git push`).
 
 Let's fix that:
 
@@ -130,9 +137,9 @@ $ jj describe -m "add a comment to main"
 Working copy now at: vmunwxsk 9410db49 add a comment to main
 Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
 $ jj git push -c @
-Creating branch push-vmunwxsksqvk for revision @
-Branch changes to push to origin:
-  Add branch push-vmunwxsksqvk to 9410db49f9ba
+Creating bookmark push-vmunwxsksqvk for revision vmunwxsksqvk
+Changes to push to origin:
+  Add bookmark push-vmunwxsksqvk to 9410db49f9ba
 $ jj log
 @  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 push-vmunwxsksqvk 9410db49
 │  add a comment to main

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -60,17 +60,18 @@ Remember, `jj new` won't move any branches, and so if we push, nothing happens:
 
 ```console
 $ jj git push
-No branches found in the default push revset, `remote_branches(remote=origin)..@`.
+Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
 Nothing changed.
 ```
 
 First we have to update the branch to point at our new commit, and then push:
 
 ```console
-$ jj branch set push-vmunwxsksqvk
+$ jj bookmark set push-vmunwxsksqvk
+Moved 1 bookmarks to nzsvmmzl ad6b9b14 push-vmunwxsksqvk* | respond to feedback
 $ jj git push
-Branch changes to push to origin:
-  Move branch push-vmunwxsksqvk from 9410db49f9ba to ad6b9b149f88
+Changes to push to origin:
+  Move forward bookmark push-vmunwxsksqvk from 9410db49f9ba to ad6b9b149f88
 ```
 
 ![a screenshot of github, showing the new commit below our review](../images/new-pr-commit.png)
@@ -124,7 +125,8 @@ First, we have to undo what we just did. Here's where we are:
 So let's move the branch backwards, then abandon our new change:
 
 ```console
-$ jj branch set push-vmunwxsksqvk -r @- --allow-backwards
+$ jj bookmark set push-vmunwxsksqvk -r @- --allow-backwards
+Moved 1 bookmarks to vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment to main
 $ jj edit vmunwxsk
 Working copy now at: vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment to main
 Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
@@ -166,8 +168,8 @@ already been "rebased" in a sense. So we can just push:
 
 ```console
 > jj git push
-Branch changes to push to origin:
-  Force branch push-vmunwxsksqvk from ad6b9b149f88 to 586ea9fd213f
+Changes to push to origin:
+  Move sideways bookmark push-vmunwxsksqvk from ad6b9b149f88 to 586ea9fd213f
 ```
 
 We can see that reflected on GitHub:
@@ -233,9 +235,10 @@ Let's update our branch and push:
 
 ```console
 > jj branch set push-vmunwxsksqvk
+Moved 1 bookmarks to msmntwvo 8f7dcd91 push-vmunwxsksqvk* | add a new function
 > jj git push
-Branch changes to push to origin:
-  Force branch push-vmunwxsksqvk from 586ea9fd213f to 8f7dcd91ecbf
+Changes to push to origin:
+  Move sideways bookmark push-vmunwxsksqvk from 586ea9fd213f to 8f7dcd91ecbf
 ```
 
 We now have two changes again. So what happens when we address our review? Well,
@@ -296,8 +299,8 @@ Working copy now at: msmntwvo 752534be push-vmunwxsksqvk* | add a new function
 Parent commit      : vmunwxsk f6f7dce9 add a comment to main
 Added 0 files, modified 1 files, removed 0 files
 $ jj git push
-Branch changes to push to origin:
-  Force branch push-vmunwxsksqvk from 8f7dcd91ecbf to 752534beb39f
+Changes to push to origin:
+  Move sideways bookmark push-vmunwxsksqvk from 8f7dcd91ecbf to 752534beb39f
 ```
 
 And now we're good! Just that easy. If we didn't want to move `@`, we could have


### PR DESCRIPTION
Apparently I decided to walk through the tutorial a week after some significant deprecations in `jj`, as branches got renamed to bookmarks ([0.22.0 changelog](https://github.com/martinvonz/jj/blob/main/CHANGELOG.md#0220---2024-10-02)) :smile:. This means that some of the code blocks in chapters "Branching, merging, and conflicts" and "Sharing your code with others" now produce deprecation warnings, such as:

```
remote_branches() is deprecated; use remote_bookmarks() instead
```
and

```
Warning: `jj branch` is deprecated; use `jj bookmark` instead, which is equivalent
Warning: `jj branch` will be removed in a future version, and this will be a hard error
```

As far as I can see, apart from the deprecations, the output of some commands changed (e.g "force branch" became "moved sideways bookmark"), and some commands are now more verbose (`jj bookmark set` now prints which bookmarks moved where) compared to the current text - not sure if the latter change is part of 0.22 or earlier (because I had no previous experience).

The only behavior change which I spotted is that  `jj git push` now creates a new commit (and prints `Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it`). This does not seem to matter for the subsequent steps in the tutorial (other than the empty commit is visible in subsequent `jj log`).

In this PR I updated the code blocks with the non-deprecated commands and their outputs, based on what I could see when following the tutorial. I did not want to make large changes to the text (at least not initially), so I made changes only in places where it felt wrong *not* to mention bookmarks, but by and large the narrative remains about branches.

This seems to be a relatively fresh topic. Should I also try update the narrative?