### PR TITLE
"jj new -B" now requires symbol

### DIFF
--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -64,7 +64,7 @@ What we want to do is make a new change before this one. So let's do that.
 Let's try this:
 
 ```console
-$ jj new -B -m "add more comments"
+$ jj new -B @ -m "add more comments"
 Rebased 1 descendant commits
 Working copy now at: nmptruqn 30a1f33b (empty) add more comments
 Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello


### PR DESCRIPTION
`jj new -B` now requires you to specify which commit you're inserting before.

When I used the original command, I got this message:

```
$ jj new -B -m "add more comments"
error: a value is required for '--insert-before <INSERT_BEFORE>' but none was supplied

For more information, try '--help'.
```