### PR TITLE
Revert incorrect change from 55f38dc7ccb236a4ff972dbe4c7ae0805267b57f

### DIFF
--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -176,7 +176,7 @@ We can see that reflected on GitHub:
 
 ![a screenshot of github showing that our branch was force pushed](../images/force-push-pr.png)
 
-Only one commit, and it shows that our comment is on an outdated commit.
+Only one commit, and it shows that our comment is on an outdated diff.
 
 This is really "rewriting" more than "rebasing," but rebasing also involve
 rewriting history and you may additionally want to rebase 

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -176,7 +176,7 @@ We can see that reflected on GitHub:
 
 ![a screenshot of github showing that our branch was force pushed](../images/force-push-pr.png)
 
-Only one commit, and it shows that our comment is on an outdated comment.
+Only one commit, and it shows that our comment is on an outdated commit.
 
 This is really "rewriting" more than "rebasing," but rebasing also involve
 rewriting history and you may additionally want to rebase 


### PR DESCRIPTION
Addresses https://github.com/steveklabnik/jujutsu-tutorial/pull/33#discussion_r1817875686

55f38dc7ccb236a4ff972dbe4c7ae0805267b57f changed the word "commit" to "comment", but I'm pretty sure the original word was the intended one; "comment is on an outdated comment" doesn't really make sense, whereas "comment is on an outdated commit" does.

Update: per https://github.com/steveklabnik/jujutsu-tutorial/pull/47#discussion_r1817877277, I think "comment is on an outdated diff" is even better/more accurate, so I've updated to that.