### PR TITLE
Fix mistake in conflicts.md

### DIFF
--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -177,7 +177,7 @@ Then run `jj squash` to move the resolution into the conflicted commit.
 This advice is good, but also more complex than we need to do right now. Doing
 this is a great way to handle a complex resolution, where you want to double
 check what you've done before you apply the changes. But we are just using a
-small example to make a point. Therefore, we can just edit `povouosxlror` and
+small example to make a point. Therefore, we can just edit `povouosx` and
 remove the conflict markers directly:
 
 ```console


### PR DESCRIPTION
The text mentions the change ID that jj proposed to edit, but the point is to edit the other change ID instead, as shown in the command below.

This makes the text consistent with the command below.