### PR TITLE
Update Remotes page title

### DIFF
--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -1,4 +1,4 @@
-# Working with remotes, aka, GitHub
+# Working with remotes, e.g., GitHub
 
 We're going to talk about working with remote `git` servers, and using GitHub as
 an example. The same principles apply to any given `git` server, though.


### PR DESCRIPTION
"Working with remotes, AKA, Github" implies that "remotes" are "also known as Github". However as the rest of doc states, Github is just one example of a `git` server which can be used as a Remote. 

Rewording to "Working with remotes, e.g., Github" clarifies in the title that Github is not "The Remote" but "A Remote".
