### PR TITLE
Change to "latest" URL in linking to official docs installation page

### DIFF
--- a/src/hello-world/how-to-install.md
+++ b/src/hello-world/how-to-install.md
@@ -7,7 +7,7 @@ For the full range of ways to install `jj`, you can visit the [Installation and
 Setup][install] page of the official documentation. Personally, because I am
 a Rust developer, and `jj` is written in Rust, I installed my copy like this:
 
-[install]: https://martinvonz.github.io/jj/v0.23.0/install-and-setup/
+[install]: https://martinvonz.github.io/jj/latest/install-and-setup/
 
 ```console
 $ cargo install jj-cli@0.23.0 --locked


### PR DESCRIPTION
Using `latest` in place of `vX.YY.Z` makes it auto link to the docs for the most recent release.

The old v0.23 page that's currently linked to doesn't have instructions to setup dynamic command-line completion, for eg., so users might miss out on updates like that to the page. (It's easy to miss the version number at the top, or not realize it's not the latest, unless you're specifically looking for it.)