### PR TITLE
Replace x with ●

### DIFF
--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -123,7 +123,7 @@ This will bring up a TUI!
 
 By default, it's showing a file-level view: we have our one file, and the `( )` indicates that
 we haven't selected to include this. We could do so by hitting space, and that
-will fill the parenthesis in with an x:
+will fill the parenthesis in with a ● (screenshot outdated and shows an x):
 
 ![same shot but with the box checked](../images/jj-squash-02.png)
 


### PR DESCRIPTION
The images and text refer to old symbols no longer used by the TUI since this [1] commit

Solves #59

[1] https://github.com/arxanas/scm-record/commit/54fd3a50d65cb44dec7520b5044fd40f9baf0738