### PR TITLE
typo: remove `!` to match example text

### DIFF
--- a/src/hello-world/describing-commits.md
+++ b/src/hello-world/describing-commits.md
@@ -19,7 +19,7 @@ The simplest way to use it is with the `-m`, or "message" flag. This allows us
 to pass the description on the command line:
 
 ```console
-$ jj describe -m "hello world!"
+$ jj describe -m "hello world"
 Working copy now at: yyrsmnoo 524d2bf4 hello world
 Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
 ```


### PR DESCRIPTION
`$ jj describe -m "hello world!"` has an exclamation mark that is missing from the example output throughout the rest of this document. 