### PR TITLE
"aka" -> "e.g." for Working with remotes chapter

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -23,7 +23,7 @@
 
 - [Sharing your code with others](sharing-code/intro.md)
     - [Using named branches in jj](sharing-code/named-branches.md)
-    - [Working with remotes, aka, GitHub](sharing-code/remotes.md)
+    - [Working with remotes, e.g., GitHub](sharing-code/remotes.md)
     - [Responding to pull request feedback](sharing-code/updating-prs.md)
     - [Updating trunk from upstream]()
     - [Using jj with Gerrit]()

--- a/src/sharing-code/intro.md
+++ b/src/sharing-code/intro.md
@@ -8,6 +8,6 @@ that let us collaborate.
 Here's what we're going to learn:
 
 * Using named branches in jj
-* Working with remotes, aka, GitHub
+* Working with remotes, e.g., GitHub
 * Adding commits to a pull request
 * How to use `jj` with Gerrit rather than GitHub


### PR DESCRIPTION
The chapter heading within the chapter was "Working with remotes, e.g., GitHub" but the table of contents and chapter summary both had "aka" instead of "e.g." -- it seems like "e.g." makes more sense given that the principles of the chapter apply to any remote git repository, so this change just makes it consistent.

Ironically I didn't make this change with `jj`. I'm still reading the tutorial!