### PR TITLE
Replace stub (^C^V) intro for "More advanced workflows"

### DIFF
--- a/src/advanced/more-advanced-workflows.md
+++ b/src/advanced/more-advanced-workflows.md
@@ -1,9 +1,9 @@
 # More advanced workflows
 
-One of the best parts about using a version control system is the ability to
-share that code with other people. So far, we've been using jj entirely on our
-own machine, but it's time to explore how we can interface with tools that let
-us collaborate.
+The workflows we've seen in `jj` are different from `git` in the best ways. As we
+get a bit more advanced, there are some very impressive possibilities yet to
+see. This section will also address an interesting aspect of interoperability
+between `jj` and `git`: colocated repositories.
 
 Here's what we're going to learn:
 

--- a/src/hello-world/viewing-contents.md
+++ b/src/hello-world/viewing-contents.md
@@ -1,4 +1,4 @@
-# Viewing the contents of your repository with jj log
+# Viewing the contents of your repository with `jj log`
 
 Let's look at our chain of changes:
 

--- a/src/introduction/introduction.md
+++ b/src/introduction/introduction.md
@@ -24,13 +24,13 @@ some people never try again, and some who try don't get over the hump, but this
 used to happen quite often, enough to be remarkable. So that's what I decided
 with `jj`. I'd figure this stuff out later.
 
-Well, recently [Chris Krycho wrote an article about jj][chris]. I liked it. I
+Well, recently [Chris Krycho wrote an article about `jj`][chris]. I liked it. I
 didn't fully grok everything, but it at least felt like I could understand this
 thing finally maybe. I didn't install it, but just sat with it for a while.
 
 I don't know if that is why, but I awoke unusually early one morning. I
 couldn't get back to sleep. Okay. Fine. Let's do this. I opened up [the official
-jj tutorial][jj-vevo], installed `jj`, made this repository on GitHub, followed
+`jj` tutorial][jj-vevo], installed `jj`, made this repository on GitHub, followed
 the "cloning a git repo" instructions to pull it down, and started this mdBook.
 
 What follows is exactly what the title says: it's to teach me `jj`. I am

--- a/src/introduction/what-is-jj-and-why-should-i-care.md
+++ b/src/introduction/what-is-jj-and-why-should-i-care.md
@@ -1,4 +1,4 @@
-# What is jj and why should I care?
+# What is `jj` and why should I care?
 
 `jj` is the name of the CLI for [Jujutsu][jj]. Jujutsu is a DVCS, or
 "distributed version control system." You may be familiar with other DVCSes,

--- a/src/sharing-code/intro.md
+++ b/src/sharing-code/intro.md
@@ -7,7 +7,7 @@ that let us collaborate.
 
 Here's what we're going to learn:
 
-* Using named branches in jj
+* Using named branches in `jj`
 * Working with remotes, e.g., GitHub
 * Adding commits to a pull request
 * How to use `jj` with Gerrit rather than GitHub


### PR DESCRIPTION
Section 6, "More advanced workflows", had an intro paragraph copied and pasted from the previous section ("Sharing your code with others")--which is how I create new sections, too, to be fair--so I wrote a simple summary. The primary author will probably want to replace it in his own voice, but this is a more serviceable stub in the meantime.
