### PR TITLE
Correct link to documentation on templates

### DIFF
--- a/src/customization/templates.md
+++ b/src/customization/templates.md
@@ -44,4 +44,4 @@ Templates are powerful, and let you do a lot of interesting things. I would
 suggest reading [the documentation on templates][templates] to learn all of the
 details.
 
-[templates]: https://martinvonz.github.io/jj/v0.14.0/templates/
+[templates]: https://jj-vcs.github.io/jj/latest/templates/


### PR DESCRIPTION
The given link is a 404 at the moment.