### PR TITLE
Fix typo in Rebasing example

### DIFF
--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -261,7 +261,6 @@ and update `src/main.rs`:
 /// The main function runs when our program starts
 fn main() {
     print("Hello, world!");
-    print("Goodbye, world!");
 }
 
 // a function that prints a message


### PR DESCRIPTION
Since we added "print(goodbye)" in the child commit, we shouldn't see it when editing the parent commit. This is what I found when following along, at least.

Thanks for making this tutorial!