### PR TITLE
Fix `mdbook build` failing due to unknown `multilingual` field

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Steve Klabnik"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Steve's Jujutsu Tutorial"
 


### PR DESCRIPTION
When cloning the project and directly running `mdbook build`, the following error was thrown: 
```
ERROR Invalid configuration file
        Caused by: TOML parse error at line 4, column 1
  |
4 | multilingual = false
  | ^^^^^^^^^^^^
unknown field `multilingual`, expected one of `title`, `authors`, `description`, `src`, `language`, `text-direction`
```
This PR simply removes the unknown `multilingual` fixing the error.