### PR TITLE
Use `rebase -o` instead of `rebase -d`

### DIFF
--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -253,10 +253,10 @@ Added 0 files, modified 1 files, removed 0 files
 Yikes! Don't worry, we can fix that with a rebase: 
 
 ```console
-> jj rebase -r xn -d m -d ym -d yx -d r -d kv
+> jj rebase -r xn -o m -o ym -o yx -o r -o kv
 ```
 
-We want to rebase the revision `xn` with the following "destination" revisions:
+We want to rebase the revision `xn` "onto" the following destination revisions:
 `m`, `ym`, `yx`, `r`, and `kv`. Since we have multiple parents, that's what will
 happen:
 
@@ -359,7 +359,7 @@ above that that is true.
 We can rebase all of our PRs with one command:
 
 ```console
-> jj rebase -s 'all:roots(trunk..@)' -d trunk
+> jj rebase -s 'all:roots(trunk..@)' -o trunk
 Rebased 14 commits
 Working copy now at: ltupzukw 9a496ef6 (empty) (no description set)
 Parent commit      : xnutwmso 6be25a32 (empty) merge: steve's branch
@@ -405,7 +405,7 @@ The next part, `all:` is a prefix. What's the prefix do? Well, let's try running
 the command without it:
 
 ```console
-> jj rebase -s 'roots(trunk..@)' -d trunk
+> jj rebase -s 'roots(trunk..@)' -o trunk
 Error: Revset "roots(trunk..@)" resolved to more than one revision
 Hint: The revset "roots(trunk..@)" resolved to these revisions:
 opwqpunl ba100a96 (empty) display the birthday date on the settings page
@@ -438,7 +438,7 @@ themselves. The roots of the tree.
 Let's put it all together:
 
 ```console
-$ jj rebase -s 'all:roots(trunk..@)' -d trunk
+$ jj rebase -s 'all:roots(trunk..@)' -o trunk
 ```
 
 > We're rebasing all of the root changes from `trunk` to `@` onto `trunk`.

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -94,7 +94,7 @@ Everything looks to be in order. Let's rebase our goodbye message change onto
 our refactor printing change:
 
 ```rust
-$ jj rebase -r povouosx -d @
+$ jj rebase -r povouosx -o @
 New conflicts appeared in these commits:
   povouosx 793ce8e0 (conflict) remove goodbye message
 To resolve the conflicts, start by updating to it:

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -169,11 +169,11 @@ rebasing a single change. Let's rebase our "create hello and goodbye functions"
 change on top of our current change:
 
 ```console
-$ jj rebase -r xrslwzvq -d pzoqtwuv
+$ jj rebase -r xrslwzvq -o pzoqtwuv
 ```
 
-This rebases a single revision with `-r`, to a certain destination revision,
-hence `-d`. Since our branch only had one revision, this would be the same as
+This rebases a single revision with `-r`, *onto* a certain destination revision,
+hence `-o`. Since our branch only had one revision, this would be the same as
 passing `-b xrslwzvq`, which would move the whole branch that revision is on,
 or `-s xrslwzvq`, which rebases that revision as well as all of its descendants.
 
@@ -277,7 +277,7 @@ $ jj log --limit 5
 We can now rebase our other change on top too:
 
 ```console
-$ jj rebase -r yykpmnuq -d xrslwzvq
+$ jj rebase -r yykpmnuq -o xrslwzvq
 $ jj log --limit 5
 ◉  yykpmnuq steve@steveklabnik.com 2024-03-01 16:35:47.000 -06:00 7bea29b6
 │  (empty) add better documentation


### PR DESCRIPTION
The `-d` flag is now an alias to `-o`, which is the recommended flag name.

[This commit](https://github.com/jj-vcs/jj/commit/4dd845db2e3749ca3cbb18ede0b38ea5af5b8143) undeprecated the `-d` flag, as it's still in wide use. Should this tutorial acknowledge its existence, in case readers encounter it?