### PR TITLE
Improve clarity in the squash workflow intro

### DIFF
--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -9,10 +9,9 @@ and contrasting the two is interesting.
 
 The workflow goes like this:
 
-1. We describe the work we want to do.
-2. We create a new empty change on top of that one.
-3. As we produce work we want to put into our change, we use `jj squash` to move
-   changes from `@` into the change where we described what to do.
+1. We describe the work we want to do, in the current change (call it `C`).
+2. We create a new empty change (now called `@`) on top of `C`.
+3. As we produce work, we use `jj squash` to move that work from `@` into `C`.
 
 In some senses, this workflow is like using the `git` index, where we have our
 list of current changes (in `@`), and we pull the ones we want into our commit


### PR DESCRIPTION
Trying to put my beginner's eyes to good use, by nailing down what made them 😵‍💫 spiral...

* “a new empty change on top of that one” — what does “that one” refer to? No change had been mentioned.
* “into our change” — what does “our change” refer to? Is it the “that one” change, or the “new empty change”?
* “move changes from `@` into the change where [...]” — and `@` identifies a change. So we move changes from a change into a change?
* “the change where we described what to do” — does “the change” here refer to _the act of_ adding a description, or to the thing we added a description _to_?

Stepping through them one by one, I think:

* “that one” refers to the latest revision, the one shown by `jj log -n 1`. So give that a name in the first step, “call it `C`”.
* “our change” refers to `C`
* it's helpful to avoid the word “change” when _not_ referencing instances of the jj concept called [Change]
* instead of “the change where we described what to do”, best to just reference the name `C`.

So here are concrete suggestions to make this less confusing, at least to me. (I think I'm a pretty representative N=1 sample of “people very used to git, and very new to jj”.)

[Change]: https://docs.jj-vcs.dev/latest/glossary/#change