### PR TITLE
Update for jj 0.44

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 book
+.DS_Store

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -38,7 +38,7 @@
     - [Undoing mistakes]()
     - [Reverting changes]()
     - [The Operation Log]()
-    - [The obslog]()
+    - [The evolog]()
 
 - [Customizing your experience]()
     - [Configuring `jj`]()

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -21,11 +21,11 @@ Let's check out our example project to make sure we're on the same place:
 
 ```console
 > jj log
-@  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+@  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │  add a new function
-◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ```
 
@@ -44,13 +44,13 @@ Working copy  (@) now at: opwqpunl 7ede4eb9 (empty) (no description set)
 Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 ~/Documents/GitHub/sample-jj-project/hello-world> jj log
-@  opwqpunl steve@steveklabnik.com 2024-03-17 14:12:52.000 -05:00 7ede4eb9
+@  opwqpunl steve@steveklabnik.com 2024-03-17 14:12:52 7ede4eb9
 │  (empty) (no description set)
-│ ◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+│ ○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │  add a new function
-│ ◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+│ ○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 ├─╯  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -72,15 +72,15 @@ Creating branch push-yxxppztpoyqq for revision @
 Branch changes to push to origin:
   Add branch push-yxxppztpoyqq to 3d1231518dbf
 > jj log
-@  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+@  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │  (empty) have galactus query eks with time range
-◉  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+○  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 │  (empty) display the birthday date on the settings page
-│ ◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+│ ○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │  add a new function
-│ ◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+│ ○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 ├─╯  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -105,27 +105,27 @@ Your `jj log` will look like this:
 
 ```console
 > jj log
-@  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31.000 -05:00 push-ymvptyyqmyul 728dbb1e
+@  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31 push-ymvptyyqmyul 728dbb1e
 │  (empty) fixing all the breakage from updating dependencies
-◉  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14.000 -05:00 1f7c69a5
+○  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 │  (empty) updating dependencies
-│ ◉  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ ○  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │  (empty) first 80% done
-│ ◉  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ ○  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 ├─╯  (empty) another feature
-│ ◉  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ ○  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │  (empty) various fixes
-│ ◉  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ ○  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 ├─╯  (empty) prepare to deploy to the cloud
-│ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ ○  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │  (empty) have galactus query eks with time range
-│ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+│ ○  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 ├─╯  (empty) display the birthday date on the settings page
-│ ◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+│ ○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │  add a new function
-│ ◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+│ ○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 ├─╯  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ```
 
@@ -181,31 +181,31 @@ Check out this `jj log`:
 
 ```console
 > jj log
-@  nllzosqm steve@steveklabnik.com 2024-03-17 14:36:36.000 -05:00 85324040
+@  nllzosqm steve@steveklabnik.com 2024-03-17 14:36:36 85324040
 │  (empty) (no description set)
-◉          xnutwmso steve@steveklabnik.com 2024-03-17 14:30:52.000 -05:00 695806ff
+○          xnutwmso steve@steveklabnik.com 2024-03-17 14:30:52 695806ff
 ├─┬─┬─┬─╮  (empty) merge: steve's branch
-│ │ │ │ ◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+│ │ │ │ ○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │ │ │ │  add a new function
-│ │ │ │ ◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+│ │ │ │ ○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 │ │ │ │ │  add a comment to main
-│ │ │ ◉ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ │ │ ○ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ ◉ │  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+│ │ │ ○ │  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 │ │ │ ├─╯  (empty) display the birthday date on the settings page
-│ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │ │ │  (empty) various fixes
-│ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ ◉ │  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ ○ │  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │ │  (empty) first 80% done
-│ ◉ │  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ ○ │  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 │ ├─╯  (empty) another feature
-◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31.000 -05:00 push-ymvptyyqmyul 728dbb1e
+○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31 push-ymvptyyqmyul 728dbb1e
 │ │  (empty) fixing all the breakage from updating dependencies
-◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14.000 -05:00 1f7c69a5
+○ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 ├─╯  (empty) updating dependencies
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ```
 
@@ -222,31 +222,31 @@ Working copy  (@) now at: kvupxvpv 2ea49586 (empty) second 80% done
 Parent commit (@-)      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
 Added 0 files, modified 1 files, removed 0 files
 > jj log
-    @  kvupxvpv steve@steveklabnik.com 2024-03-17 14:43:28.000 -05:00 46cb6847
+    @  kvupxvpv steve@steveklabnik.com 2024-03-17 14:43:28 46cb6847
     | (empty) second 80% done
-  ◉ |      xnutwmso steve@steveklabnik.com 2024-03-17 14:30:52.000 -05:00 695806ff
+  ○ |      xnutwmso steve@steveklabnik.com 2024-03-17 14:30:52 695806ff
 ╭─┼─┬─┬─╮  (empty) merge: steve's branch
-◉ │ │ │ │  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+○ │ │ │ │  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │ │ │ │  add a new function
-◉ │ │ │ │  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+○ │ │ │ │  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 │ │ │ │ │  add a comment to main
-│ │ │ │ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ │ │ │ ○  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ │ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+│ │ │ │ ○  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 ├───────╯  (empty) display the birthday date on the settings page
-│ │ │ ◉  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ │ │ ○  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │ │ │  (empty) various fixes
-│ │ │ ◉  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ │ │ ○  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 ├─────╯  (empty) prepare to deploy to the cloud
-│ │ ◉  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ │ ○  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │ │  (empty) first 80% done
-│ │ ◉  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ │ ○  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 ├───╯  (empty) another feature
-│ ◉  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31.000 -05:00 push-ymvptyyqmyul 728dbb1e
+│ ○  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31 push-ymvptyyqmyul 728dbb1e
 │ │  (empty) fixing all the breakage from updating dependencies
-│ ◉  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14.000 -05:00 1f7c69a5
+│ ○  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 ├─╯  (empty) updating dependencies
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ```
 
@@ -262,19 +262,19 @@ happen:
 
 ```console
 > jj log
-◉          xnutwmso steve@steveklabnik.com 2024-03-17 15:16:36.000 -05:00 da67dfe1
+○          xnutwmso steve@steveklabnik.com 2024-03-17 15:16:36 da67dfe1
 ├─┬─┬─┬─╮  (empty) merge: steve's branch
-│ │ │ │ @  kvupxvpv steve@steveklabnik.com 2024-03-17 15:15:20.000 -05:00 2ea49586
+│ │ │ │ @  kvupxvpv steve@steveklabnik.com 2024-03-17 15:15:20 2ea49586
 │ │ │ │ │  (empty) second 80% done
-│ │ │ │ ◉  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ │ │ │ ○  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │ │ │ │  (empty) first 80% done
-│ │ │ │ ◉  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ │ │ │ ○  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 │ │ │ │ │  (empty) another feature
-│ │ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ │ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │ │ │ │  (empty) various fixes
-│ │ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ │ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 │ │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ │ ◉ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ │ ○ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │ │ │  (empty) have galactus query eks with time range
 <snip>
 ~
@@ -289,9 +289,9 @@ Working copy  (@) now at: pptrunzw 06442487 (empty) (no description set)
 Parent commit (@-)      : xnutwmso bcf8a74b (empty) merge: steve's branch
 Added 0 files, modified 2 files, removed 0 files
 > jj log
-@  pptrunzw steve@steveklabnik.com 2024-03-17 14:55:59.000 -05:00 06442487
+@  pptrunzw steve@steveklabnik.com 2024-03-17 14:55:59 06442487
 │  (empty) (no description set)
-◉          xnutwmso steve@steveklabnik.com 2024-03-17 14:52:08.000 -05:00 bcf8a74b
+○          xnutwmso steve@steveklabnik.com 2024-03-17 14:52:08 bcf8a74b
 ├─┬─┬─┬─╮  (empty) merge: steve's branch
 
 <snip>
@@ -316,35 +316,35 @@ After fetching changes, our log looks like this:
 ```console
 > jj git fetch
 > jj log
-@  xqkmpxlq steve@steveklabnik.com 2024-03-17 15:18:11.000 -05:00 fccf0626
+@  xqkmpxlq steve@steveklabnik.com 2024-03-17 15:18:11 fccf0626
 │  (empty) (no description set)
-◉          xnutwmso steve@steveklabnik.com 2024-03-17 15:16:36.000 -05:00 da67dfe1
+○          xnutwmso steve@steveklabnik.com 2024-03-17 15:16:36 da67dfe1
 ├─┬─┬─┬─╮  (empty) merge: steve's branch
-│ │ │ │ ◉  kvupxvpv steve@steveklabnik.com 2024-03-17 15:15:20.000 -05:00 2ea49586
+│ │ │ │ ○  kvupxvpv steve@steveklabnik.com 2024-03-17 15:15:20 2ea49586
 │ │ │ │ │  (empty) second 80% done
-│ │ │ │ ◉  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ │ │ │ ○  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │ │ │ │  (empty) first 80% done
-│ │ │ │ ◉  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ │ │ │ ○  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 │ │ │ │ │  (empty) another feature
-│ │ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ │ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │ │ │ │  (empty) various fixes
-│ │ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ │ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 │ │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ │ ◉ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ │ ○ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │ │ │  (empty) have galactus query eks with time range
-│ │ ◉ │  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+│ │ ○ │  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 │ │ ├─╯  (empty) display the birthday date on the settings page
-│ ◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31.000 -05:00 push-ymvptyyqmyul 728dbb1e
+│ ○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31 push-ymvptyyqmyul 728dbb1e
 │ │ │  (empty) fixing all the breakage from updating dependencies
-│ ◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14.000 -05:00 1f7c69a5
+│ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 │ ├─╯  (empty) updating dependencies
-◉ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 14:45:41.000 -05:00 push-vmunwxsksqvk* cdca9211
+○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 14:45:41 push-vmunwxsksqvk* cdca9211
 │ │  add a new function
-◉ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 14:45:41.000 -05:00 3a08be8a
+○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 14:45:41 3a08be8a
 ├─╯  add a comment to main
-│ ◉  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02.000 -05:00 trunk b7f9d708
+│ ◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 trunk b7f9d708
 ╭─╯  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -449,35 +449,35 @@ Here's what our `jj log` looks like:
 
 ```console
 > jj log
-◉  xnutwmso steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 ce833ae7
+○  xnutwmso steve@steveklabnik.com 2024-03-17 16:01:56 ce833ae7
 │  (empty) merge: steve's branch
-◉          xqkmpxlq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 5dc292c2
+○          xqkmpxlq steve@steveklabnik.com 2024-03-17 16:01:56 5dc292c2
 ├─┬─┬─┬─╮  (empty) (no description set)
-│ │ │ │ │ @  ltupzukw steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 edf9cd58
+│ │ │ │ │ @  ltupzukw steve@steveklabnik.com 2024-03-17 16:01:56 edf9cd58
 ╭─┬─┬─┬─┬─╯  (empty) (no description set)
-│ │ │ │ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-yxxppztpoyqq* b3db74d3
+│ │ │ │ ○  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56 push-yxxppztpoyqq* b3db74d3
 │ │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ │ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 713c692d
+│ │ │ │ ○  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56 713c692d
 │ │ │ │ │  (empty) display the birthday date on the settings page
-│ │ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-rxpztwmsszvk* 76dbbcd1
+│ │ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56 push-rxpztwmsszvk* 76dbbcd1
 │ │ │ │ │  (empty) various fixes
-│ │ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d0f7f627
+│ │ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56 d0f7f627
 │ │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ │ ◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-ymvptyyqmyul* f448e93a
+│ │ ○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56 push-ymvptyyqmyul* f448e93a
 │ │ │ │  (empty) fixing all the breakage from updating dependencies
-│ │ ◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d608ebd3
+│ │ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56 d608ebd3
 │ │ ├─╯  (empty) updating dependencies
-│ ◉ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-vmunwxsksqvk* 21569f7a
+│ ○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56 push-vmunwxsksqvk* 21569f7a
 │ │ │  (empty) add a new function
-│ ◉ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 9a050939
+│ ○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56 9a050939
 │ ├─╯  (empty) add a comment to main
-◉ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 3b0a722a
+○ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56 3b0a722a
 │ │  (empty) second 80% done
-◉ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-zxyukunnwolo* 7e826ad4
+○ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56 push-zxyukunnwolo* 7e826ad4
 │ │  (empty) first 80% done
-◉ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 792cc601
+○ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56 792cc601
 ├─╯  (empty) another feature
-◉  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02.000 -05:00 trunk b7f9d708
+◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 trunk b7f9d708
 │  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
 ~
 ```
@@ -491,35 +491,35 @@ Parent commit (@-)      : xnutwmso ce833ae7 (empty) merge: steve's branch
 > jj abandon l
 Abandoned commit ltupzukw edf9cd58 (empty) (no description set)
 > jj log
-@  vvvouunp steve@steveklabnik.com 2024-03-17 16:02:39.000 -05:00 78919d69
+@  vvvouunp steve@steveklabnik.com 2024-03-17 16:02:39 78919d69
 │  (empty) (no description set)
-◉  xnutwmso steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 ce833ae7
+○  xnutwmso steve@steveklabnik.com 2024-03-17 16:01:56 ce833ae7
 │  (empty) merge: steve's branch
-◉          xqkmpxlq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 5dc292c2
+○          xqkmpxlq steve@steveklabnik.com 2024-03-17 16:01:56 5dc292c2
 ├─┬─┬─┬─╮  (empty) (no description set)
-│ │ │ │ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-yxxppztpoyqq* b3db74d3
+│ │ │ │ ○  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56 push-yxxppztpoyqq* b3db74d3
 │ │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ │ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 713c692d
+│ │ │ │ ○  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56 713c692d
 │ │ │ │ │  (empty) display the birthday date on the settings page
-│ │ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-rxpztwmsszvk* 76dbbcd1
+│ │ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56 push-rxpztwmsszvk* 76dbbcd1
 │ │ │ │ │  (empty) various fixes
-│ │ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d0f7f627
+│ │ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56 d0f7f627
 │ │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ │ ◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-ymvptyyqmyul* f448e93a
+│ │ ○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56 push-ymvptyyqmyul* f448e93a
 │ │ │ │  (empty) fixing all the breakage from updating dependencies
-│ │ ◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d608ebd3
+│ │ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56 d608ebd3
 │ │ ├─╯  (empty) updating dependencies
-│ ◉ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-vmunwxsksqvk* 21569f7a
+│ ○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56 push-vmunwxsksqvk* 21569f7a
 │ │ │  (empty) add a new function
-│ ◉ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 9a050939
+│ ○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56 9a050939
 │ ├─╯  (empty) add a comment to main
-◉ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 3b0a722a
+○ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56 3b0a722a
 │ │  (empty) second 80% done
-◉ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-zxyukunnwolo* 7e826ad4
+○ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56 push-zxyukunnwolo* 7e826ad4
 │ │  (empty) first 80% done
-◉ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 792cc601
+○ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56 792cc601
 ├─╯  (empty) another feature
-◉  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02.000 -05:00 trunk b7f9d708
+◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 trunk b7f9d708
 │  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
 ~
 ```
@@ -545,31 +545,31 @@ And now our log is clean:
 
 ```text
 > jj log
-@  vvvouunp steve@steveklabnik.com 2024-03-17 16:06:15.000 -05:00 e3f9254f
+@  vvvouunp steve@steveklabnik.com 2024-03-17 16:06:15 e3f9254f
 │  (empty) (no description set)
-◉  xnutwmso steve@steveklabnik.com 2024-03-17 16:06:15.000 -05:00 0459bd1c
+○  xnutwmso steve@steveklabnik.com 2024-03-17 16:06:15 0459bd1c
 │  (empty) merge: steve's branch
-◉        xqkmpxlq steve@steveklabnik.com 2024-03-17 16:06:15.000 -05:00 c9e5fa35
+○        xqkmpxlq steve@steveklabnik.com 2024-03-17 16:06:15 c9e5fa35
 ├─┬─┬─╮  (empty) (no description set)
-│ │ │ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-yxxppztpoyqq* b3db74d3
+│ │ │ ○  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56 push-yxxppztpoyqq* b3db74d3
 │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 713c692d
+│ │ │ ○  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56 713c692d
 │ │ │ │  (empty) display the birthday date on the settings page
-│ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-rxpztwmsszvk* 76dbbcd1
+│ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56 push-rxpztwmsszvk* 76dbbcd1
 │ │ │ │  (empty) various fixes
-│ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d0f7f627
+│ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56 d0f7f627
 │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ ◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-ymvptyyqmyul* f448e93a
+│ ○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56 push-ymvptyyqmyul* f448e93a
 │ │ │  (empty) fixing all the breakage from updating dependencies
-│ ◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d608ebd3
+│ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56 d608ebd3
 │ ├─╯  (empty) updating dependencies
-◉ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 3b0a722a
+○ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56 3b0a722a
 │ │  (empty) second 80% done
-◉ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-zxyukunnwolo* 7e826ad4
+○ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56 push-zxyukunnwolo* 7e826ad4
 │ │  (empty) first 80% done
-◉ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 792cc601
+○ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56 792cc601
 ├─╯  (empty) another feature
-◉  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02.000 -05:00 push-vmunwxsksqvk* trunk b7f9d708
+◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 push-vmunwxsksqvk* trunk b7f9d708
 │  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
 ~
 ```

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -360,7 +360,7 @@ above that that is true.
 We can rebase all of our PRs with one command:
 
 ```console
-> jj rebase -s 'all:roots(trunk..@)' -o trunk
+> jj rebase -s 'roots(trunk..@)' -o trunk
 Rebased 14 commits to destination.
 Working copy  (@) now at: ltupzukw 9a496ef6 (empty) (no description set)
 Parent commit (@-)      : xnutwmso 6be25a32 (empty) merge: steve's branch
@@ -372,8 +372,8 @@ This is using `jj rebase -s` rather than `-r`, like we've been doing before. Her
 the description from `jj rebase --help`:
 
 ```text
-  -s, --source <SOURCE>
-          Rebase specified revision(s) together their tree of descendants (can be repeated)
+  -s, --source <REVSETS>
+          Rebase specified revision(s) together with their trees of descendants (can be repeated)
 ```
 
 That's a little rough. There are some helpful diagrams in `jj rebase --help` that
@@ -402,29 +402,10 @@ A - B
 
 as both `C` and `D` are somewhere else now. `-b` works to rebase a branch.
 
-The next part, `all:` is a prefix. What's the prefix do? Well, let's try running
-the command without it:
-
-```console
-> jj rebase -s 'roots(trunk..@)' -o trunk
-Error: Revset "roots(trunk..@)" resolved to more than one revision
-Hint: The revset "roots(trunk..@)" resolved to these revisions:
-opwqpunl ba100a96 (empty) display the birthday date on the settings page
-tmnmvxyy 462dcf72 (empty) prepare to deploy to the cloud
-tzsloruo fdba6abd (empty) another feature
-xulymzyp abbf424e (empty) updating dependencies
-vmunwxsk?? 2ce46bd0 (empty) add a comment to main
-Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:roots(trunk..@)').
-```
-
-This is basically a way to help make sure you've got the right arguments: sometimes
-when working with revsets, you expect the result to be only one revision, and
-sometimes you expect it to be many revisions. For some commands, one or the
-other may be not necessarily what you want. In this case, most of the time,
-when you rebase, you only want one parent. So if we use a revset that returns
-more than one change, that might be a bug! So `jj rebase` wants us to reassure
-it that we are creating a change with multiple parents by putting `all:` as a
-prefix.
+Note that `-s` takes a revset that may resolve to many revisions, and every one
+of them gets rebased. Older versions of `jj` made you write an `all:` prefix
+(`'all:roots(trunk..@)'`) to confirm you meant more than one revision. That
+prefix has been removed; passing it now is a parse error.
 
 Finally, `trunk..@` is being passed to the `roots()` function. `trunk..@` is
 a range, so it will give every change between where `trunk` is and `@`. The
@@ -439,7 +420,7 @@ themselves. The roots of the tree.
 Let's put it all together:
 
 ```console
-$ jj rebase -s 'all:roots(trunk..@)' -o trunk
+$ jj rebase -s 'roots(trunk..@)' -o trunk
 ```
 
 > We're rebasing all of the root changes from `trunk` to `@` onto `trunk`.

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -254,6 +254,7 @@ Yikes! Don't worry, we can fix that with a rebase:
 
 ```console
 > jj rebase -r xn -o m -o ym -o yx -o r -o kv
+Rebased 1 commits to destination.
 ```
 
 We want to rebase the revision `xn` "onto" the following destination revisions:
@@ -360,7 +361,7 @@ We can rebase all of our PRs with one command:
 
 ```console
 > jj rebase -s 'all:roots(trunk..@)' -o trunk
-Rebased 14 commits
+Rebased 14 commits to destination.
 Working copy  (@) now at: ltupzukw 9a496ef6 (empty) (no description set)
 Parent commit (@-)      : xnutwmso 6be25a32 (empty) merge: steve's branch
 ```
@@ -489,7 +490,8 @@ Let's move `@` back to where we want it:
 Working copy  (@) now at: vvvouunp 78919d69 (empty) (no description set)
 Parent commit (@-)      : xnutwmso ce833ae7 (empty) merge: steve's branch
 > jj abandon l
-Abandoned commit ltupzukw edf9cd58 (empty) (no description set)
+Abandoned 1 commits:
+  ltupzukw edf9cd58 (empty) (no description set)
 > jj log
 @  vvvouunp steve@steveklabnik.com 2024-03-17 16:02:39 78919d69
 │  (empty) (no description set)
@@ -530,12 +532,14 @@ that branch:
 
 ```console
 > jj abandon push-vmunwxsksqvk
-Abandoned commit msmntwvo?? 21569f7a push-vmunwxsksqvk* | (empty) add a new function
+Abandoned 1 commits:
+  msmntwvo?? 21569f7a push-vmunwxsksqvk* | (empty) add a new function
 Rebased 3 descendant commits onto parents of abandoned commits
 Working copy  (@) now at: vvvouunp ace3f1a2 (empty) (no description set)
 Parent commit (@-)      : xnutwmso 32871810 (empty) merge: steve's branch
 > jj abandon push-vmunwxsksqvk
-Abandoned commit vmunwxsk?? 9a050939 push-vmunwxsksqvk* | (empty) add a comment to main
+Abandoned 1 commits:
+  vmunwxsk?? 9a050939 push-vmunwxsksqvk* | (empty) add a comment to main
 Rebased 3 descendant commits onto parents of abandoned commits
 Working copy  (@) now at: vvvouunp e3f9254f (empty) (no description set)
 Parent commit (@-)      : xnutwmso 0459bd1c (empty) merge: steve's branch

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -40,8 +40,8 @@ other:
 
 ```console
 > jj new trunk
-Working copy now at: opwqpunl 7ede4eb9 (empty) (no description set)
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: opwqpunl 7ede4eb9 (empty) (no description set)
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 ~/Documents/GitHub/sample-jj-project/hello-world> jj log
 @  opwqpunl steve@steveklabnik.com 2024-03-17 14:12:52.000 -05:00 7ede4eb9
@@ -62,11 +62,11 @@ matter for our purposes.
 
 ```console
 > jj describe -m "display the birthday date on the settings page"
-Working copy now at: opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 > jj new -m "have galactus query eks with time range"
-Working copy now at: yxxppztp 3d123151 (empty) have galactus query eks with time range
-Parent commit      : opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
+Working copy  (@) now at: yxxppztp 3d123151 (empty) have galactus query eks with time range
+Parent commit (@-)      : opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
 > jj git push -c @
 Creating branch push-yxxppztpoyqq for revision @
 Branch changes to push to origin:
@@ -90,11 +90,11 @@ three times. It's cooler with more branches, trust me.
 
 ```console
 > jj new trunk -m "prepare to deploy to the cloud"
-Working copy now at: tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 > jj new -m "various fixes"
-Working copy now at: rxpztwms 902a6cd2 (empty) various fixes
-Parent commit      : tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
+Working copy  (@) now at: rxpztwms 902a6cd2 (empty) various fixes
+Parent commit (@-)      : tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
 > jj git push -c @
 Creating branch push-rxpztwmsszvk for revision @
 Branch changes to push to origin:
@@ -145,12 +145,12 @@ of them! Anyway:
 
 ```console
 > jj new ym z r yx m -m "merge: steve's branch"
-Working copy now at: xnutwmso 695806ff (empty) merge: steve's branch
-Parent commit      : ymvptyyq 728dbb1e push-ymvptyyqmyul | (empty) fixing all the breakage from updating dependencies
-Parent commit      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
-Parent commit      : rxpztwms 902a6cd2 push-rxpztwmsszvk | (empty) various fixes
-Parent commit      : yxxppztp 3d123151 push-yxxppztpoyqq | (empty) have galactus query eks with time range
-Parent commit      : msmntwvo 752534be push-vmunwxsksqvk | add a new function
+Working copy  (@) now at: xnutwmso 695806ff (empty) merge: steve's branch
+Parent commit (@-)      : ymvptyyq 728dbb1e push-ymvptyyqmyul | (empty) fixing all the breakage from updating dependencies
+Parent commit (@-)      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
+Parent commit (@-)      : rxpztwms 902a6cd2 push-rxpztwmsszvk | (empty) various fixes
+Parent commit (@-)      : yxxppztp 3d123151 push-yxxppztpoyqq | (empty) have galactus query eks with time range
+Parent commit (@-)      : msmntwvo 752534be push-vmunwxsksqvk | add a new function
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -173,8 +173,8 @@ squash-style workflow more easily: we temporarily work on a `@` change, and then
 
 ```console
 > jj new
-Working copy now at: nllzosqm 85324040 (empty) (no description set)
-Parent commit      : xnutwmso 695806ff (empty) merge: steve's branch
+Working copy  (@) now at: nllzosqm 85324040 (empty) (no description set)
+Parent commit (@-)      : xnutwmso 695806ff (empty) merge: steve's branch
 ```
 
 Check out this `jj log`:
@@ -218,8 +218,8 @@ it's not too bad:
 
 ```console
 > jj new z -m "second 80% done"
-Working copy now at: kvupxvpv 2ea49586 (empty) second 80% done
-Parent commit      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
+Working copy  (@) now at: kvupxvpv 2ea49586 (empty) second 80% done
+Parent commit (@-)      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
 Added 0 files, modified 1 files, removed 0 files
 > jj log
     @  kvupxvpv steve@steveklabnik.com 2024-03-17 14:43:28.000 -05:00 46cb6847
@@ -285,8 +285,8 @@ shuffle. It was empty anyway! Let's bring it back:
 
 ```console
 > jj new xn
-Working copy now at: pptrunzw 06442487 (empty) (no description set)
-Parent commit      : xnutwmso bcf8a74b (empty) merge: steve's branch
+Working copy  (@) now at: pptrunzw 06442487 (empty) (no description set)
+Parent commit (@-)      : xnutwmso bcf8a74b (empty) merge: steve's branch
 Added 0 files, modified 2 files, removed 0 files
 > jj log
 @  pptrunzw steve@steveklabnik.com 2024-03-17 14:55:59.000 -05:00 06442487
@@ -361,8 +361,8 @@ We can rebase all of our PRs with one command:
 ```console
 > jj rebase -s 'all:roots(trunk..@)' -o trunk
 Rebased 14 commits
-Working copy now at: ltupzukw 9a496ef6 (empty) (no description set)
-Parent commit      : xnutwmso 6be25a32 (empty) merge: steve's branch
+Working copy  (@) now at: ltupzukw 9a496ef6 (empty) (no description set)
+Parent commit (@-)      : xnutwmso 6be25a32 (empty) merge: steve's branch
 ```
 
 This is using some revset stuff we haven't seen before! Let's break it down:
@@ -486,8 +486,8 @@ Let's move `@` back to where we want it:
 
 ```console
 > jj new xn
-Working copy now at: vvvouunp 78919d69 (empty) (no description set)
-Parent commit      : xnutwmso ce833ae7 (empty) merge: steve's branch
+Working copy  (@) now at: vvvouunp 78919d69 (empty) (no description set)
+Parent commit (@-)      : xnutwmso ce833ae7 (empty) merge: steve's branch
 > jj abandon l
 Abandoned commit ltupzukw edf9cd58 (empty) (no description set)
 > jj log
@@ -532,13 +532,13 @@ that branch:
 > jj abandon push-vmunwxsksqvk
 Abandoned commit msmntwvo?? 21569f7a push-vmunwxsksqvk* | (empty) add a new function
 Rebased 3 descendant commits onto parents of abandoned commits
-Working copy now at: vvvouunp ace3f1a2 (empty) (no description set)
-Parent commit      : xnutwmso 32871810 (empty) merge: steve's branch
+Working copy  (@) now at: vvvouunp ace3f1a2 (empty) (no description set)
+Parent commit (@-)      : xnutwmso 32871810 (empty) merge: steve's branch
 > jj abandon push-vmunwxsksqvk
 Abandoned commit vmunwxsk?? 9a050939 push-vmunwxsksqvk* | (empty) add a comment to main
 Rebased 3 descendant commits onto parents of abandoned commits
-Working copy now at: vvvouunp e3f9254f (empty) (no description set)
-Parent commit      : xnutwmso 0459bd1c (empty) merge: steve's branch
+Working copy  (@) now at: vvvouunp e3f9254f (empty) (no description set)
+Parent commit (@-)      : xnutwmso 0459bd1c (empty) merge: steve's branch
 ```
 
 And now our log is clean:

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -68,9 +68,9 @@ Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Working copy  (@) now at: yxxppztp 3d123151 (empty) have galactus query eks with time range
 Parent commit (@-)      : opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
 > jj git push -c @
-Creating branch push-yxxppztpoyqq for revision @
-Branch changes to push to origin:
-  Add branch push-yxxppztpoyqq to 3d1231518dbf
+Creating bookmark push-yxxppztpoyqq for revision yxxppztpoyqq
+Changes to push to origin:
+  bookmark: push-yxxppztpoyqq [add to 3d1231518dbf]
 > jj log
 @  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │  (empty) have galactus query eks with time range
@@ -96,9 +96,9 @@ Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Working copy  (@) now at: rxpztwms 902a6cd2 (empty) various fixes
 Parent commit (@-)      : tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
 > jj git push -c @
-Creating branch push-rxpztwmsszvk for revision @
-Branch changes to push to origin:
-  Add branch push-rxpztwmsszvk to 902a6cd22f30
+Creating bookmark push-rxpztwmsszvk for revision rxpztwmsszvk
+Changes to push to origin:
+  bookmark: push-rxpztwmsszvk [add to 902a6cd22f30]
 ```
 
 Your `jj log` will look like this:
@@ -165,7 +165,7 @@ squash-style workflow more easily: we temporarily work on a `@` change, and then
 > ```sh
 > jj absorb         # absorb from @ into appropriate mutable parents
 > jj absorb src/    # limit to a file tree
-> jj absorb -f @ -t mutable()  # explicit source/target
+> jj absorb -f @ --into 'mutable()'  # explicit source/target
 > jj op show -p     # inspect the planned moves
 > ```
 >

--- a/src/branching-merging-and-conflicts/anonymous-branches.md
+++ b/src/branching-merging-and-conflicts/anonymous-branches.md
@@ -125,21 +125,21 @@ We can see that there's a branch in the output of `jj log`:
 
 ```console
 $ jj log
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 │  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
-◉  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40.000 -06:00 ed71bb54
+○  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40 ed71bb54
 │  print goodbye as well as hello
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 We've got our two changes, and there's a fork in the road.
@@ -163,11 +163,11 @@ We do it like this:
 
 ```console
 > jj log -r 'heads(all())'
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 │  (empty) create hello and goodbye functions
 ~
 
-◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 │  (empty) add better documentation
 ~
 ```

--- a/src/branching-merging-and-conflicts/anonymous-branches.md
+++ b/src/branching-merging-and-conflicts/anonymous-branches.md
@@ -55,8 +55,8 @@ use `jj new` to create one. We want to start from a blank slate here.
 
 ```console
 $ jj new
-Working copy now at: yykpmnuq 0bc7a425 (empty) (no description set)
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: yykpmnuq 0bc7a425 (empty) (no description set)
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 A common reason for branching is to work on two different ideas at once. Let's
@@ -68,8 +68,8 @@ to be working on that:
 
 ```console
 > jj describe -m "add better documentation"
-Working copy now at: yykpmnuq 4a95c1f9 (empty) add better documentation
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: yykpmnuq 4a95c1f9 (empty) add better documentation
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 Next, we want to make a change to work on our hello and goodbye functions.
@@ -77,8 +77,8 @@ We want this change to build on top of `ootnlvpt`, so we can just say that:
 
 ```console
 $ jj new o
-Working copy now at: xrslwzvq e9249c85 (empty) (no description set)
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: xrslwzvq e9249c85 (empty) (no description set)
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 We want to create our new change with the parent `o`, which we could see is the
@@ -90,8 +90,8 @@ Let's describe this one too:
 
 ```console
 $ jj describe -m "create hello and goodbye functions"
-Working copy now at: xrslwzvq a70d464c (empty) create hello and goodbye functions
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: xrslwzvq a70d464c (empty) create hello and goodbye functions
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 Excellent. We've got two different changes, `yykpmnuq` and `xrslwzvq`, both with

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -84,7 +84,7 @@ Excellent:
 $ jj log --limit 3
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
-│ ×  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
+│ ○  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
 ├─╯  remove goodbye message
 ○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
@@ -319,7 +319,7 @@ So fix the conflict in `main.rs` again, and then let's see what happens:
 ```console
 > jj log --limit 4
 Rebased 1 descendant commits onto updated working copy.
-×  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
+○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
 │  (empty) (no description set)
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -82,11 +82,11 @@ Excellent:
 
 ```console
 $ jj log --limit 3
-@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12.000 -06:00 5f858c15
+@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
-│ ◉  povouosx steve@steveklabnik.com 2024-03-01 17:27:14.000 -06:00 28010506
+│ ○  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
 ├─╯  remove goodbye message
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -111,11 +111,11 @@ as there's only one commit that starts like this.)
 
 ```console
 > jj log --limit 3
-◉  povouosx steve@steveklabnik.com 2024-03-01 17:30:32.000 -06:00 793ce8e0 conflict
+○  povouosx steve@steveklabnik.com 2024-03-01 17:30:32 793ce8e0 conflict
 │  remove goodbye message
-@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12.000 -06:00 5f858c15
+@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -151,11 +151,11 @@ And then we check our log again:
 ```console
 $ jj log --limit 3
 Rebased 1 descendant commits onto updated working copy
-◉  povouosx steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 a912c809 conflict
+○  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
 │  remove goodbye message
-@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -246,11 +246,11 @@ M src/main.rs
 Working copy  (@) : povouosx 7647f7a0 remove goodbye message
 Parent commit (@-): vvmrvwuz d41c079b refactor printing
 $ jj log --limit 3
-@  povouosx steve@steveklabnik.com 2024-03-01 18:08:23.000 -06:00 7647f7a0
+@  povouosx steve@steveklabnik.com 2024-03-01 18:08:23 7647f7a0
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -277,13 +277,13 @@ Added 0 files, modified 1 files, removed 0 files
 > jj new povouosxlror --no-edit
 Created new commit mlzwmxzs 07bb727d (conflict) (empty) (no description set)
 > jj log --limit 4
-◉  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:10:08.000 -06:00 07bb727d conflict
+○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:10:08 07bb727d conflict
 │  (empty) (no description set)
-@  povouosx steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 a912c809 conflict
+@  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -293,13 +293,13 @@ So fix the conflict in `main.rs` again, and then let's see what happens:
 ```console
 > jj log --limit 4
 Rebased 1 descendant commits onto updated working copy
-◉  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 9a4ad229
+○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
 │  (empty) (no description set)
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
+@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -84,7 +84,7 @@ Excellent:
 $ jj log --limit 3
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
-│ ○  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
+│ ×  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
 ├─╯  remove goodbye message
 ○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
@@ -95,23 +95,22 @@ our refactor printing change:
 
 ```console
 $ jj rebase -r povouosx -o @
-New conflicts appeared in these commits:
+Rebased 1 commits to destination.
+New conflicts appeared in 1 commits:
   povouosx 793ce8e0 (conflict) remove goodbye message
-To resolve the conflicts, start by updating to it:
-  jj new povouosxlror
+Hint: To resolve the conflicts, start by creating a commit on top of
+the conflicted commit:
+  jj new povouosx
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 ```
 
 Wait a minute, I thought I told you that rebases always succeed. Well... it did:
-(And, as an aside, `povouosxlror` is giving a few more letters of the change ID
-than `povouosx` used elsewhere. Both can be used interchangeably at this point
-as there's only one commit that starts like this.)
 
 ```console
 > jj log --limit 3
-○  povouosx steve@steveklabnik.com 2024-03-01 17:30:32 793ce8e0 conflict
+×  povouosx steve@steveklabnik.com 2024-03-01 17:30:32 793ce8e0 (conflict)
 │  remove goodbye message
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
@@ -151,7 +150,7 @@ And then we check our log again:
 ```console
 $ jj log --limit 3
 Rebased 1 descendant commits onto updated working copy.
-○  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
+×  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 (conflict)
 │  remove goodbye message
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
@@ -170,10 +169,11 @@ automatically.
 The output we got back when the conflict was created gave us some advice:
 
 ```text
-To resolve the conflicts, start by updating to it:
-  jj new povouosxlror
+Hint: To resolve the conflicts, start by creating a commit on top of
+the conflicted commit:
+  jj new povouosx
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 ```
 
@@ -188,6 +188,8 @@ remove the conflict markers directly:
 Working copy  (@) now at: povouosx a912c809 (conflict) remove goodbye message
 Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 Added 0 files, modified 1 files, removed 0 files
+Warning: There are unresolved conflicts at these paths:
+src/main.rs    2-sided conflict
 ```
 
 Here's `src/main.rs`:
@@ -198,29 +200,50 @@ Here's `src/main.rs`:
 /// This is the best implementation of this program to ever exist.
 
 fn main() {
-<<<<<<<
-+++++++
+<<<<<<< conflict 1 of 1
++++++++ vvmrvwuz d41c079b "refactor printing" (rebase destination)
     print("Hello, world!");
     print("Goodbye, world!");
-%%%%%%%
-     print_hello();
--    print_goodbye();
->>>>>>>
 }
 
 // a function that prints a message
 fn print(m: &str) {
     println!("{m}")
 }
+%%%%%%% diff from: yykpmnuq 2b93da0c "add better documentation" (parents of rebased revision)
+\\\\\\\        to: povouosx 28010506 "remove goodbye message" (rebased revision)
+     print_hello();
+-    print_goodbye();
+ }
+ 
+ fn print_hello() {
+     println!("Hello, world!");
+ }
+-
+-fn print_goodbye() {
+-    println!("Goodbye, world!");
+-}
+>>>>>>> conflict 1 of 1 ends
 ```
 
 `git` uses a combination of `<<<<`, `=====`, and `>>>>` to mark conflicts. `jj`
-has more rich conflict markers. It still uses the `>>>` and `<<<`s to indicate
-the start and end, but has two other markers: `+++++++` and `%%%%%%%`. The `+`s
-indicate the start of a snapshot, and `%`s mark the start of a diff. So we can
-see that we have two `print` lines, but our changes wanted to remove one of them,
-but since that's not the same thing, conflict. To resolve this, we apply our own
-take on the diff to the snapshot:
+has richer conflict markers. It still uses the `>>>` and `<<<`s to indicate the
+start and end, but has two others: `+++++++` marks a snapshot, and `%%%%%%%`
+marks a diff. Each one is labelled with the commit it came from, which is what
+makes them readable.
+
+So: the snapshot is the destination we rebased onto, `vvmrvwuz`, verbatim. Then
+the diff is our own change, expressed as what `povouosx` did to its old parent
+`yykpmnuq` — it dropped the `print_goodbye()` call and the whole
+`print_goodbye` function. `jj` couldn't apply that diff to that snapshot,
+because the lines it wanted to remove aren't there any more; `vvmrvwuz` rewrote
+them into `print(...)` calls. So it hands you both halves and lets you do it.
+
+Notice how much of the file is inside the conflict region. `jj` isn't
+conflicting on one line — the diff and the snapshot overlap across most of
+`main()` and the functions below it, so the whole span gets marked.
+
+To resolve this, we apply our own take on the diff to the snapshot:
 
 ```rust
 /// A "Hello, world!" program.
@@ -264,22 +287,25 @@ and then we'll make a new change on top of our conflicted change:
 
 ```console
 > jj undo
-New conflicts appeared in these commits:
+Undid operation: 3c9a71fd50e2 (2024-03-01 18:08:23) snapshot working copy
+Restored to operation: 8b40cc21ae77 (2024-03-01 17:49:07) snapshot working copy
+New conflicts appeared in 1 commits:
   povouosx a912c809 (conflict) remove goodbye message
-To resolve the conflicts, start by updating to it:
-  jj new povouosxlror
+Hint: To resolve the conflicts, start by creating a commit on top of
+the conflicted commit:
+  jj new povouosx
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 Working copy  (@) now at: povouosx a912c809 (conflict) remove goodbye message
 Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 Added 0 files, modified 1 files, removed 0 files
-> jj new povouosxlror --no-edit
+> jj new povouosx --no-edit
 Created new commit mlzwmxzs 07bb727d (conflict) (empty) (no description set)
 > jj log --limit 4
-○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:10:08 07bb727d conflict
+×  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:10:08 07bb727d (conflict)
 │  (empty) (no description set)
-@  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
+@  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 (conflict)
 │  remove goodbye message
 ○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
@@ -293,7 +319,7 @@ So fix the conflict in `main.rs` again, and then let's see what happens:
 ```console
 > jj log --limit 4
 Rebased 1 descendant commits onto updated working copy.
-○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
+×  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
 │  (empty) (no description set)
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
@@ -312,7 +338,8 @@ right now:
 
 ```console
 $ jj abandon mlzwmxzs
-Abandoned commit mlzwmxzs 9a4ad229 (empty) (no description set)
+Abandoned 1 commits:
+  mlzwmxzs 9a4ad229 (empty) (no description set)
 ```
 
 Great, we've cleaned that up.

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -9,8 +9,8 @@ Let's deliberately introduce a conflict. First, we make a new change:
 
 ```console
 $ jj new -m "remove goodbye message"
-Working copy now at: povouosx e2c9628c (empty) remove goodbye message
-Parent commit      : yykpmnuq 2b93da0c (empty) add better documentation
+Working copy  (@) now at: povouosx e2c9628c (empty) remove goodbye message
+Parent commit (@-)      : yykpmnuq 2b93da0c (empty) add better documentation
 ```
 
 And then update `src/main.rs` appropriately:
@@ -33,8 +33,8 @@ Let's also make a new change off of the previous head:
 
 ```console
 $ jj new yykpmnuq -m "refactor printing"
-Working copy now at: vvmrvwuz 44205653 (empty) refactor printing
-Parent commit      : yykpmnuq 2b93da0c (empty) add better documentation
+Working copy  (@) now at: vvmrvwuz 44205653 (empty) refactor printing
+Parent commit (@-)      : yykpmnuq 2b93da0c (empty) add better documentation
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -185,8 +185,8 @@ remove the conflict markers directly:
 
 ```console
 > jj edit povouosx
-Working copy now at: povouosx a912c809 (conflict) remove goodbye message
-Parent commit      : vvmrvwuz d41c079b refactor printing
+Working copy  (@) now at: povouosx a912c809 (conflict) remove goodbye message
+Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -243,8 +243,8 @@ Let's take a look:
 $ jj st
 Working copy changes:
 M src/main.rs
-Working copy : povouosx 7647f7a0 remove goodbye message
-Parent commit: vvmrvwuz d41c079b refactor printing
+Working copy  (@) : povouosx 7647f7a0 remove goodbye message
+Parent commit (@-): vvmrvwuz d41c079b refactor printing
 $ jj log --limit 3
 @  povouosx steve@steveklabnik.com 2024-03-01 18:08:23.000 -06:00 7647f7a0
 │  remove goodbye message
@@ -271,8 +271,8 @@ To resolve the conflicts, start by updating to it:
 Then use `jj resolve`, or edit the conflict markers in the file directly.
 Once the conflicts are resolved, you may want inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
-Working copy now at: povouosx a912c809 (conflict) remove goodbye message
-Parent commit      : vvmrvwuz d41c079b refactor printing
+Working copy  (@) now at: povouosx a912c809 (conflict) remove goodbye message
+Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 Added 0 files, modified 1 files, removed 0 files
 > jj new povouosxlror --no-edit
 Created new commit mlzwmxzs 07bb727d (conflict) (empty) (no description set)

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -150,7 +150,7 @@ And then we check our log again:
 
 ```console
 $ jj log --limit 3
-Rebased 1 descendant commits onto updated working copy
+Rebased 1 descendant commits onto updated working copy.
 ○  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
 │  remove goodbye message
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
@@ -292,7 +292,7 @@ So fix the conflict in `main.rs` again, and then let's see what happens:
 
 ```console
 > jj log --limit 4
-Rebased 1 descendant commits onto updated working copy
+Rebased 1 descendant commits onto updated working copy.
 ○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
 │  (empty) (no description set)
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -242,7 +242,7 @@ Let's take a look:
 ```console
 $ jj st
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : povouosx 7647f7a0 remove goodbye message
 Parent commit: vvmrvwuz d41c079b refactor printing
 $ jj log --limit 3

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -194,7 +194,7 @@ src/main.rs    2-sided conflict
 
 Here's `src/main.rs`:
 
-```rust
+```rust,ignore
 /// A "Hello, world!" program.
 /// 
 /// This is the best implementation of this program to ever exist.

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -112,7 +112,8 @@ Let's try merging all three in at the same time:
 
 ```console
 $ jj new pzoqtwuv yykpmnuq xrslwzvq -m "merge three branches"
-Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Working copy  (@) now at: vuztuxmz 717232df (empty) merge three branches
+Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
 Parent commit (@-)      : xrslwzvq a70d464c (empty) create hello and goodbye functions
 $ jj log --limit 6

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -45,8 +45,8 @@ is already getting a little long.
 ## Merging branches
 
 Now, you may expect that you'd use a command like `jj merge` to merge branches
-together. However, as of `0.14.0`, `jj merge` is deprecated, and will be removed
-some time later this year. So how the heck do we create merges?
+together. There is no such command: it was deprecated in `0.14.0` and has since
+been removed. So how the heck do we create merges?
 
 Well, what is a merge anyway? It's a new change that has more than one parent.
 How do we make new changes? With `jj new`. So let's ask it to make a change that

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -19,8 +19,8 @@ on our main branch while we were doing the work:
 
 ```console
 > jj new o -m "added some cool new feature"
-Working copy now at: pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 Let's take a look:
@@ -54,9 +54,9 @@ has both `pzoqtwuv` and `yykpmnuq` as parents:
 
 ```console
 > jj new pzoqtwuv yykpmnuq -m "merge better documentation"
-Working copy now at: rxzyvnkx f1c1bde8 (empty) merge better documentation
-Parent commit      : pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : yykpmnuq 210283e8 (empty) add better documentation
+Working copy  (@) now at: rxzyvnkx f1c1bde8 (empty) merge better documentation
+Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
 ```
 
 Just like we'd pass a parent revision to `jj new`, we can pass multiple parents,
@@ -88,8 +88,8 @@ I haven't told you about yet:
 
 ```console
 $ jj undo
-Working copy now at: pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
 │  (empty) added some cool new feature
@@ -110,9 +110,9 @@ Let's try merging all three in at the same time:
 
 ```console
 $ jj new pzoqtwuv yykpmnuq xrslwzvq -m "merge three branches"
-Working copy now at: pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : yykpmnuq 210283e8 (empty) add better documentation
-Parent commit      : xrslwzvq a70d464c (empty) create hello and goodbye functions
+Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
+Parent commit (@-)      : xrslwzvq a70d464c (empty) create hello and goodbye functions
 $ jj log --limit 6
 @      vuztuxmz steve@steveklabnik.com 2024-03-01 15:38:49.000 -06:00 717232df
 ├─┬─╮  (empty) merge three branches
@@ -147,8 +147,8 @@ Let's undo our merge again:
 
 ```console
 $ jj undo
-Working copy now at: pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
 │  (empty) added some cool new feature
@@ -259,8 +259,8 @@ but what about when we *do* want to move `@`? Well, the fact that the
 
 ```console
 $ jj edit xrslwzvq
-Working copy now at: xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
-Parent commit      : pzoqtwuv 9353442b (empty) added some cool new feature
+Working copy  (@) now at: xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
+Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
 $ jj log --limit 5
 @  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
 │  (empty) create hello and goodbye functions
@@ -297,8 +297,8 @@ isn't that hard. But we can also use a revset:
 
 ```console
 $ jj edit @+
-Working copy now at: yykpmnuq 7bea29b6 (empty) add better documentation
-Parent commit      : xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
+Working copy  (@) now at: yykpmnuq 7bea29b6 (empty) add better documentation
+Parent commit (@-)      : xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
 ```
 
 `+` means "the child of this revision", so `@+` is "the child revision of the

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -4,11 +4,11 @@ Let's recall where we are:
 
 ```console
 > jj log
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 │  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ```
 
@@ -27,15 +27,15 @@ Let's take a look:
 
 ```console
 > jj log --limit 5
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 ├─╯  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -65,17 +65,17 @@ choosing six as the limit since we just added a new change:
 
 ```console
 > jj log --limit 6
-@    rxzyvnkx steve@steveklabnik.com 2024-03-01 15:21:11.000 -06:00 f1c1bde8
+@    rxzyvnkx steve@steveklabnik.com 2024-03-01 15:21:11 f1c1bde8
 ├─╮  (empty) merge better documentation
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 │ │  (empty) add better documentation
-◉ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+○ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 ├─╯  (empty) added some cool new feature
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 ├─╯  (empty) create hello and goodbye functions
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -91,15 +91,15 @@ $ jj undo
 Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 ├─╯  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -114,17 +114,17 @@ Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
 Parent commit (@-)      : xrslwzvq a70d464c (empty) create hello and goodbye functions
 $ jj log --limit 6
-@      vuztuxmz steve@steveklabnik.com 2024-03-01 15:38:49.000 -06:00 717232df
+@      vuztuxmz steve@steveklabnik.com 2024-03-01 15:38:49 717232df
 ├─┬─╮  (empty) merge three branches
-│ │ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ │ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 │ │ │  (empty) create hello and goodbye functions
-│ ◉ │  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○ │  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 │ ├─╯  (empty) add better documentation
-◉ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+○ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 ├─╯  (empty) added some cool new feature
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -150,15 +150,15 @@ $ jj undo
 Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 ├─╯  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -181,15 +181,15 @@ We didn't get any output though. Let's look at our log:
 
 ```console
 $ jj log --limit 5
-◉  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -222,17 +222,17 @@ flag you can pass instead to create a new change but not modify `@`:
 $ jj new -m "not gonna start this yet" --no-edit
 Created new commit owlpoptm df6620cb (empty) not gonna start this yet
 $ jj log --limit 6
-◉  owlpoptm steve@steveklabnik.com 2024-03-01 16:28:54.000 -06:00 df6620cb
+○  owlpoptm steve@steveklabnik.com 2024-03-01 16:28:54 df6620cb
 │  (empty) not gonna start this yet
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+│ ○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 ├─╯  (empty) create hello and goodbye functions
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -241,15 +241,15 @@ New change, yet we're still where we are. Let's undo that real quick:
 ```console
 $ jj undo
 $ jj log --limit 5
-◉  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -262,15 +262,15 @@ $ jj edit xrslwzvq
 Working copy  (@) now at: xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
 Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
 $ jj log --limit 5
-@  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+@  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
-◉  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+○  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -279,15 +279,15 @@ We can now rebase our other change on top too:
 ```console
 $ jj rebase -r yykpmnuq -o xrslwzvq
 $ jj log --limit 5
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 16:35:47.000 -06:00 7bea29b6
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 16:35:47 7bea29b6
 │  (empty) add better documentation
-@  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+@  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
-◉  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+○  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -88,6 +88,8 @@ I haven't told you about yet:
 
 ```console
 $ jj undo
+Undid operation: 4a1f0e6c8b2d (2024-03-01 15:21:11) new empty commit
+Restored to operation: 91c33bb0d5ef (2024-03-01 15:06:59) new empty commit
 Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
@@ -147,6 +149,8 @@ Let's undo our merge again:
 
 ```console
 $ jj undo
+Undid operation: 4a1f0e6c8b2d (2024-03-01 15:21:11) new empty commit
+Restored to operation: 91c33bb0d5ef (2024-03-01 15:06:59) new empty commit
 Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
@@ -170,6 +174,7 @@ change on top of our current change:
 
 ```console
 $ jj rebase -r xrslwzvq -o pzoqtwuv
+Rebased 1 commits to destination.
 ```
 
 This rebases a single revision with `-r`, *onto* a certain destination revision,
@@ -177,7 +182,7 @@ hence `-o`. Since our branch only had one revision, this would be the same as
 passing `-b xrslwzvq`, which would move the whole branch that revision is on,
 or `-s xrslwzvq`, which rebases that revision as well as all of its descendants.
 
-We didn't get any output though. Let's look at our log:
+Note that the working copy didn't move. Let's look at our log:
 
 ```console
 $ jj log --limit 5
@@ -240,6 +245,8 @@ New change, yet we're still where we are. Let's undo that real quick:
 
 ```console
 $ jj undo
+Undid operation: 7d2b41ac9e08 (2024-03-01 16:28:54) new empty commit
+Restored to operation: 1e5f77c2ab3d (2024-03-01 16:08:37) rebase commit
 $ jj log --limit 5
 ○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
@@ -278,6 +285,7 @@ We can now rebase our other change on top too:
 
 ```console
 $ jj rebase -r yykpmnuq -o xrslwzvq
+Rebased 1 commits to destination.
 $ jj log --limit 5
 ○  yykpmnuq steve@steveklabnik.com 2024-03-01 16:35:47 7bea29b6
 │  (empty) add better documentation

--- a/src/branching-merging-and-conflicts/revsets.md
+++ b/src/branching-merging-and-conflicts/revsets.md
@@ -71,7 +71,7 @@ Another really useful revset function is `trunk()`:
 
 ```console
 $ jj log -r 'trunk()'
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 Right now, this doesn't look very useful, but it will be more useful when we

--- a/src/customization/templates.md
+++ b/src/customization/templates.md
@@ -44,4 +44,4 @@ Templates are powerful, and let you do a lot of interesting things. I would
 suggest reading [the documentation on templates][templates] to learn all of the
 details.
 
-[templates]: https://jj-vcs.github.io/jj/latest/templates/
+[templates]: https://docs.jj-vcs.dev/latest/templates/

--- a/src/customization/templates.md
+++ b/src/customization/templates.md
@@ -10,7 +10,7 @@ ourselves on what
 
 ```text
 $ jj log -r @-
-◉  yzlysuwt steve@steveklabnik.com 2024-02-29 00:35:12.000 -06:00 main f80a73c1
+○  yzlysuwt steve@steveklabnik.com 2024-02-29 00:35:12 main f80a73c1
 │  Fill out a table of contents
 ```
 
@@ -18,7 +18,7 @@ Let's give it a template instead:
 
 ```console
 $  jj log -r @- -T 'separate(" ", change_id, description.first_line())'
-◉  yzlysuwtylswszxknppsyqxqoktqpqpz Fill out a table of contents
+○  yzlysuwtylswszxknppsyqxqoktqpqpz Fill out a table of contents
 │
 ```
 
@@ -33,7 +33,7 @@ What if we wanted a nicer change ID? We can do that:
 
 ```console
 $  jj log -r @- -T 'separate(" ", change_id.shortest(8), description.first_line())'
-◉  yzlysuwt Fill out a table of contents
+○  yzlysuwt Fill out a table of contents
 │
 ```
 

--- a/src/hello-world/creating-a-repository.md
+++ b/src/hello-world/creating-a-repository.md
@@ -45,7 +45,34 @@ Initialized repo in "."
 Now, you may be wondering, "why not just `jj init`?" The deal is this: the
 native repository format is still a work in progress. So we're creating a
 repository that's backed by a real `git` repository, because in practice, this
-early in `jj`'s life, that's the right thing to do.
+early in `jj`'s life, that's the right thing to do. There's no `jj init`
+command at all; if you type it, `jj` will tell you that you probably wanted
+`jj git init`.
+
+If you peek at the directory listing, you'll notice something: `jj git init`
+made *two* directories.
+
+```console
+$ ls -d .git .jj
+.git
+.jj
+```
+
+This is called a "colocated" repository: a `.jj` directory and a real `.git`
+directory side by side, over one working copy. It's the default. `jj` imports
+from and exports to the `git` repository on every command, so `git`, `gh`, your
+editor, and CI all see a perfectly normal `git` repo. `git log` will show you
+the commits you make with `jj`:
+
+```console
+$ git log --oneline
+c4b8fac hello world
+```
+
+Don't use this as an excuse to run `git` commands that *change* things, though.
+Let `jj` do the mutating, or the two tools will fight over the same store. If
+you'd rather not have a `.git` directory at all, pass `--no-colocate`, and the
+`git` repository gets tucked away inside `.jj` where other tools can't see it.
 
 Anyway, now we've got a repository! In the next section, we'll take a peek
 inside.

--- a/src/hello-world/creating-new-changes.md
+++ b/src/hello-world/creating-new-changes.md
@@ -5,8 +5,8 @@ that work by using `jj new`:
 
 ```console
 $ jj new
-Working copy now at: puomrwxl 01a35aad (empty) (no description set)
-Parent commit      : yyrsmnoo ac691d85 hello world
+Working copy  (@) now at: puomrwxl 01a35aad (empty) (no description set)
+Parent commit (@-)      : yyrsmnoo ac691d85 hello world
 ```
 
 It's that easy! We now have a new change, `puomrwxl`, that's empty and has
@@ -16,9 +16,9 @@ Let's check out `jj st`:
 
 ```console
 $ jj st
-The working copy is clean
-Working copy : puomrwxl 01a35aad (empty) (no description set)
-Parent commit: yyrsmnoo ac691d85 hello world
+The working copy has no changes.
+Working copy  (@) : puomrwxl 01a35aad (empty) (no description set)
+Parent commit (@-): yyrsmnoo ac691d85 hello world
 ```
 
 Nice, a clean working copy: all of our changes were made in `yyrsmnoo`, and
@@ -30,8 +30,8 @@ change. This time, I'm going to describe things first, before I make any changes
 
 ```console
 > jj describe -m "it's important to comment our code"
-Working copy now at: puomrwxl a0f0bc71 (empty) it's important to comment our code
-Parent commit      : yyrsmnoo ac691d85 hello world
+Working copy  (@) now at: puomrwxl a0f0bc71 (empty) it's important to comment our code
+Parent commit (@-)      : yyrsmnoo ac691d85 hello world
 ```
 
 Just what we expected, still an empty change, but with a description, and our
@@ -53,8 +53,8 @@ We can double check that `jj` has noticed our change:
 $ jj st
 Working copy changes:
 M src/main.rs
-Working copy : puomrwxl 7a096b8a it's important to comment our code
-Parent commit: yyrsmnoo ac691d85 hello world
+Working copy  (@) : puomrwxl 7a096b8a it's important to comment our code
+Parent commit (@-): yyrsmnoo ac691d85 hello world
 ```
 
 Excellent, `src/main.rs` has been `M`odified, we have a new commit ID. Since
@@ -62,8 +62,8 @@ we're done with this change, let's start a new one:
 
 ```console
 $ jj new
-Working copy now at: ywnkulko 46b50ed7 (empty) (no description set)
-Parent commit      : puomrwxl 7a096b8a it's important to comment our code
+Working copy  (@) now at: ywnkulko 46b50ed7 (empty) (no description set)
+Parent commit (@-)      : puomrwxl 7a096b8a it's important to comment our code
 ```
 
 Wonderful.

--- a/src/hello-world/creating-new-changes.md
+++ b/src/hello-world/creating-new-changes.md
@@ -52,12 +52,12 @@ We can double check that `jj` has noticed our change:
 ```console
 $ jj st
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : puomrwxl 7a096b8a it's important to comment our code
 Parent commit: yyrsmnoo ac691d85 hello world
 ```
 
-Excellent, `src\main.rs` has been `M`odified, we have a new commit ID. Since
+Excellent, `src/main.rs` has been `M`odified, we have a new commit ID. Since
 we're done with this change, let's start a new one:
 
 ```console

--- a/src/hello-world/describing-commits.md
+++ b/src/hello-world/describing-commits.md
@@ -8,11 +8,36 @@ Let's set some quick configuration:
 
 ```console
 $ jj config set --user user.name "Steve Klabnik"
+Warning: This setting will only impact future commits.
+The author of the working copy will stay "you <you@example.com>".
+To change the working copy author, use "jj metaedit --update-author".
 $ jj config set --user user.email "steve@steveklabnik.com"
+Warning: This setting will only impact future commits.
+The author of the working copy will stay "you <you@example.com>".
+To change the working copy author, use "jj metaedit --update-author".
 ```
 
 Obviously, unless you're me, you should be putting your own name and email in
-there. Okay, with that out of the way, we're ready to describe some changes.
+there.
+
+About that warning: we created our repository before we set our identity, and
+`jj` had already made a working copy change for us at that point, stamped with
+whatever identity it could find. Changing the setting doesn't reach back and
+rewrite it. Since our first change is about to be described anyway, let's just
+fix the author on it:
+
+```console
+$ jj metaedit --update-author
+Modified 1 commits:
+  qzmzpxyl bc915fcd (no description set)
+Working copy  (@) now at: qzmzpxyl bc915fcd (no description set)
+Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+```
+
+`jj metaedit` changes a commit's metadata without touching its contents. Set
+your identity before `jj git init` next time and you'll never see the warning.
+
+Okay, with that out of the way, we're ready to describe some changes.
 
 Whenever we feel like it, we can describe our changes with `jj describe`.
 The simplest way to use it is with the `-m`, or "message" flag. This allows us

--- a/src/hello-world/describing-commits.md
+++ b/src/hello-world/describing-commits.md
@@ -20,8 +20,8 @@ to pass the description on the command line:
 
 ```console
 $ jj describe -m "hello world"
-Working copy now at: yyrsmnoo 524d2bf4 hello world
-Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+Working copy  (@) now at: yyrsmnoo 524d2bf4 hello world
+Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
 ```
 
 (You may notice that the change ID changed here: that's just some book-writing
@@ -69,8 +69,8 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
 After saving and closing, we'll get this output:
 
 ```console
-Working copy now at: yyrsmnoo ac691d85 hello world
-Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+Working copy  (@) now at: yyrsmnoo ac691d85 hello world
+Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
 ```
 
 We only see that first line, but the rest are still there.
@@ -79,8 +79,8 @@ Eagle eyed readers may notice one other change. Let's take two of these outputs
 and put them next to each other:
 
 ```text
-Working copy now at: yyrsmnoo 524d2bf4 hello world
-Working copy now at: yyrsmnoo ac691d85 hello world
+Working copy  (@) now at: yyrsmnoo 524d2bf4 hello world
+Working copy  (@) now at: yyrsmnoo ac691d85 hello world
 ```
 
 Changing our description changed the commit ID! This is why we have both IDs:

--- a/src/hello-world/describing-commits.md
+++ b/src/hello-world/describing-commits.md
@@ -61,7 +61,7 @@ JJ: This commit contains the following changes:
 JJ:     A .gitignore
 JJ:     A Cargo.lock
 JJ:     A Cargo.toml
-JJ:     A src\main.rs
+JJ:     A src/main.rs
 
 JJ: Lines starting with "JJ: " (like this one) will be removed.
 ```

--- a/src/hello-world/how-to-install.md
+++ b/src/hello-world/how-to-install.md
@@ -1,6 +1,6 @@
 # How to install `jj`
 
-This tutorial is written when `jj` is at version 0.23.0. It may work for
+This tutorial is written when `jj` is at version 0.44.0. It may work for
 later versions, but you also may need to adapt.
 
 For the full range of ways to install `jj`, you can visit the [Installation and
@@ -10,7 +10,7 @@ a Rust developer, and `jj` is written in Rust, I installed my copy like this:
 [install]: https://docs.jj-vcs.dev/latest/install-and-setup/
 
 ```console
-$ cargo install jj-cli@0.23.0 --locked
+$ cargo install jj-cli@0.44.0 --locked
 ```
 
 If you're not a Rust developer, please read the documentation to figure out how

--- a/src/hello-world/viewing-contents.md
+++ b/src/hello-world/viewing-contents.md
@@ -4,13 +4,13 @@ Let's look at our chain of changes:
 
 ```console
 > jj log
-@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00.000 -06:00 46b50ed7
+@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00 46b50ed7
 │  (empty) (no description set)
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 As you can see, this is sort of like `git log`, but also very different. There's

--- a/src/hello-world/viewing-the-current-status.md
+++ b/src/hello-world/viewing-the-current-status.md
@@ -30,7 +30,7 @@ Working copy changes:
 A .gitignore
 A Cargo.lock
 A Cargo.toml
-A src\main.rs
+A src/main.rs
 Working copy : qzmzpxyl bc915fcd (no description set)
 Parent commit: zzzzzzzz 00000000 (empty) (no description set)
 ```
@@ -42,7 +42,7 @@ Working copy changes:
 A .gitignore
 A Cargo.lock
 A Cargo.toml
-A src\main.rs
+A src/main.rs
 ```
 
 This is the first thing we need to talk about: unlike `git`, `jj` has no index.

--- a/src/hello-world/viewing-the-current-status.md
+++ b/src/hello-world/viewing-the-current-status.md
@@ -31,8 +31,8 @@ A .gitignore
 A Cargo.lock
 A Cargo.toml
 A src/main.rs
-Working copy : qzmzpxyl bc915fcd (no description set)
-Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+Working copy  (@) : qzmzpxyl bc915fcd (no description set)
+Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
 ```
 
 There's a surprising amount of stuff to talk about here! Let's dig into it.
@@ -63,8 +63,8 @@ copy (the files on disk) and takes a snapshot. So here, it's noticed that we've
 `A`dded some new files. You'll also see `M`odified files, and `D`eleted files.
 
 ```text
-Working copy : qzmzpxyl bc915fcd (no description set)
-Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+Working copy  (@) : qzmzpxyl bc915fcd (no description set)
+Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
 ```
 
 Our brand new repo shows that we have two *changes*. You'll notice that the

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -32,8 +32,8 @@ But since we have an empty change, what we'll actually do is:
 
 ```console
 > jj describe -m "only print hello world"
-Working copy now at: ootnlvpt bb06f041 (empty) only print hello world
-Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) now at: ootnlvpt bb06f041 (empty) only print hello world
+Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 ```
 
 We are now ready to do some work.
@@ -66,8 +66,8 @@ Let's try this:
 ```console
 $ jj new -B @ -m "add more comments"
 Rebased 1 descendant commits
-Working copy now at: nmptruqn 30a1f33b (empty) add more comments
-Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) now at: nmptruqn 30a1f33b (empty) add more comments
+Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -144,8 +144,8 @@ $ jj st
 Rebased 1 descendant commits onto updated working copy
 Working copy changes:
 M src/main.rs
-Working copy : nmptruqn 90a2e97f add more comments
-Parent commit: ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) : nmptruqn 90a2e97f add more comments
+Parent commit (@-): ywnkulko ed71bb54 print goodbye as well as hello
 ```
 
 Yet again, a rebase. Because we have changed the contents of our change,
@@ -172,8 +172,8 @@ simpler command:
 
 ```console
 $ jj next --edit
-Working copy now at: ootnlvpt e13b2585 only print hello world
-Parent commit      : nmptruqn 90a2e97f refactor printing
+Working copy  (@) now at: ootnlvpt e13b2585 only print hello world
+Parent commit (@-)      : nmptruqn 90a2e97f refactor printing
 Added 0 files, modified 1 files, removed 0 files
 ```
 

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -65,7 +65,7 @@ Let's try this:
 
 ```console
 $ jj new -B @ -m "add more comments"
-Rebased 1 descendant commits
+Rebased 1 descendant commits.
 Working copy  (@) now at: nmptruqn 30a1f33b (empty) add more comments
 Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 Added 0 files, modified 1 files, removed 0 files
@@ -77,7 +77,7 @@ We have a new flag to `jj new`, `-B`. This says to create the new change
 The first line of the output should raise some eyebrows:
 
 ```text
-Rebased 1 descendant commits
+Rebased 1 descendant commits.
 ```
 
 That's right, because we have created a change before the one we're on, it
@@ -141,7 +141,7 @@ This is very silly. Regardless, we have finished. Let's see our current status:
 
 ```console
 $ jj st
-Rebased 1 descendant commits onto updated working copy
+Rebased 1 descendant commits onto updated working copy.
 Working copy changes:
 M src/main.rs
 Working copy  (@) : nmptruqn 90a2e97f add more comments

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -143,7 +143,7 @@ This is very silly. Regardless, we have finished. Let's see our current status:
 $ jj st
 Rebased 1 descendant commits onto updated working copy
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : nmptruqn 90a2e97f add more comments
 Parent commit: ywnkulko ed71bb54 print goodbye as well as hello
 ```

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -91,17 +91,17 @@ In the meantime, let's examine our log:
 
 ```console
 $ jj log
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 22:59:46.000 -06:00 be40656e
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 22:59:46 be40656e
 │  only print hello world
-@  nmptruqn steve@steveklabnik.com 2024-02-28 22:59:46.000 -06:00 30a1f33b
+@  nmptruqn steve@steveklabnik.com 2024-02-28 22:59:46 30a1f33b
 │  (empty) add more comments
-◉  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40.000 -06:00 ed71bb54
+○  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40 ed71bb54
 │  print goodbye as well as hello
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 We can see that `@` is at our new empty change, and that we have our original
@@ -186,17 +186,17 @@ Let's double check with `jj log`:
 
 ```console
 $ jj log
-@  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+@  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  add more comments
-◉  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40.000 -06:00 ed71bb54
+○  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40 ed71bb54
 │  print goodbye as well as hello
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 That's correct, `@` is at our original change.

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -142,7 +142,8 @@ the stuff in `@` with `jj abandon`:
 
 ```console
 $ jj abandon
-Abandoned commit oopolqyp 44665581 (no description set)
+Abandoned 1 commits:
+  oopolqyp 44665581 (no description set)
 Working copy  (@) now at: ootnlvpt 97b7a559 (empty) (no description set)
 Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 Added 0 files, modified 1 files, removed 0 files

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -37,8 +37,8 @@ Let's describe the work that we want to do:
 
 ```console
 $ jj describe -m "print goodbye as well as hello"
-Working copy now at: ywnkulko 4bfe3940 (empty) print goodbye as well as hello
-Parent commit      : puomrwxl 7a096b8a it's important to comment our code
+Working copy  (@) now at: ywnkulko 4bfe3940 (empty) print goodbye as well as hello
+Parent commit (@-)      : puomrwxl 7a096b8a it's important to comment our code
 ```
 
 This change is currently empty, but we've now given it a useful name. This
@@ -51,8 +51,8 @@ our commit or not. So let's make a new one:
 
 ```console
 $ jj new
-Working copy now at: rkvxolny 5e020e00 (empty) (no description set)
-Parent commit      : ywnkulko 4bfe3940 (empty) print goodbye as well as hello
+Working copy  (@) now at: rkvxolny 5e020e00 (empty) (no description set)
+Parent commit (@-)      : ywnkulko 4bfe3940 (empty) print goodbye as well as hello
 ```
 
 We now have our change. It's also empty! There's no issue having two empty
@@ -81,8 +81,8 @@ Now that our "feature" has been implemented, let's see our current changes:
 $ jj st
 Working copy changes:
 M src/main.rs
-Working copy : rkvxolny aee5266d (no description set)
-Parent commit: ywnkulko 4bfe3940 (empty) print goodbye as well as hello
+Working copy  (@) : rkvxolny aee5266d (no description set)
+Parent commit (@-): ywnkulko 4bfe3940 (empty) print goodbye as well as hello
 ```
 
 We now have an even wilder situation than before: our current change has stuff
@@ -92,8 +92,8 @@ from our "staging area" and put it into our commit (change). We can do that with
 
 ```console
 $ jj squash
-Working copy now at: oopolqyp 9fb63b14 (empty) (no description set)
-Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) now at: oopolqyp 9fb63b14 (empty) (no description set)
+Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 ```
 
 Lots of changes here! `@` is now empty, with no description, and the parent is
@@ -143,8 +143,8 @@ the stuff in `@` with `jj abandon`:
 ```console
 $ jj abandon
 Abandoned commit oopolqyp 44665581 (no description set)
-Working copy now at: ootnlvpt 97b7a559 (empty) (no description set)
-Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) now at: ootnlvpt 97b7a559 (empty) (no description set)
+Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 Added 0 files, modified 1 files, removed 0 files
 ```
 

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -80,7 +80,7 @@ Now that our "feature" has been implemented, let's see our current changes:
 ```console
 $ jj st
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : rkvxolny aee5266d (no description set)
 Parent commit: ywnkulko 4bfe3940 (empty) print goodbye as well as hello
 ```

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -24,13 +24,13 @@ Let's recap where we are in our project: `@` currently is an empty commit:
 
 ```console
 > jj log
-@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00.000 -06:00 46b50ed7
+@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00 46b50ed7
 │  (empty) (no description set)
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 Let's describe the work that we want to do:

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -37,8 +37,8 @@ new change:
 
 ```console
 > jj new
-Working copy now at: pzkrzopz 3f14c03f (empty) (no description set)
-Parent commit      : povouosx 7ec11c41 trunk | remove goodbye message
+Working copy  (@) now at: pzkrzopz 3f14c03f (empty) (no description set)
+Parent commit (@-)      : povouosx 7ec11c41 trunk | remove goodbye message
 > jj log
 @  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 fcf669c5
 │  (empty) (no description set)

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -11,9 +11,9 @@ To create a named branch (bookmark) in `jj`, we can use `jj bookmark create`:
 ```console
 $ jj bookmark create trunk
 $ jj log --limit 2
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
 ```
 
@@ -24,9 +24,9 @@ revision or use it in a revset if we'd like:
 
 ```console
 > jj log -r 'ancestors(trunk, 2)'
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
 ~
 ```
@@ -40,11 +40,11 @@ new change:
 Working copy  (@) now at: pzkrzopz 3f14c03f (empty) (no description set)
 Parent commit (@-)      : povouosx 7ec11c41 trunk | remove goodbye message
 > jj log
-@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 fcf669c5
+@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 fcf669c5
 │  (empty) (no description set)
-│ ◉  qtlkpytx steve@steveklabnik.com 2024-03-01 20:09:25.000 -06:00 e6667f9e
+│ ○  qtlkpytx steve@steveklabnik.com 2024-03-01 20:09:25 e6667f9e
 ├─╯  (empty) (no description set)
-◉  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+○  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
 ```
 
@@ -55,11 +55,11 @@ let's forget about it:
 > jj abandon qt
 Abandoned commit qtlkpytx e6667f9e (empty) (no description set)
 > jj log --limit 3
-@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 fcf669c5
+@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 fcf669c5
 │  (empty) (no description set)
-◉  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+○  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
 ```
 
@@ -73,9 +73,9 @@ Regardless, let's update `trunk` to point at `@`:
 $ jj bookmark set trunk
 Moved 1 bookmarks to pzkrzopz fcf669c5 trunk | (empty) (no description set)
 $ jj log --limit 2
-@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 trunk fcf669c5
+@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 trunk fcf669c5
 │  (empty) (no description set)
-◉  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
+○  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
 ```
 

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -53,7 +53,8 @@ let's forget about it:
 
 ```console
 > jj abandon qt
-Abandoned commit qtlkpytx e6667f9e (empty) (no description set)
+Abandoned 1 commits:
+  qtlkpytx e6667f9e (empty) (no description set)
 > jj log --limit 3
 @  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 fcf669c5
 │  (empty) (no description set)

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -10,6 +10,7 @@ To create a named branch (bookmark) in `jj`, we can use `jj bookmark create`:
 
 ```console
 $ jj bookmark create trunk
+Created 1 bookmarks pointing to povouosx f68d1623 trunk | remove goodbye message
 $ jj log --limit 2
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -28,8 +28,8 @@ do that like this:
 
 ```console
 $ jj edit @-
-Working copy now at: povouosx f68d1623 remove goodbye message
-Parent commit      : vvmrvwuz d41c079b refactor printing
+Working copy  (@) now at: povouosx f68d1623 remove goodbye message
+Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 $ jj bookmark set trunk --allow-backwards
 Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
 $ jj abandon pzkrzopz
@@ -53,8 +53,8 @@ $ jj git push
 Changes to push to origin:
   Add bookmark trunk to f68d16233bdc
 Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-Working copy now at: znurnwmk f853107d (empty) (no description set)
-Parent commit      : povouosx f68d1623 | remove goodbye message
+Working copy  (@) now at: znurnwmk f853107d (empty) (no description set)
+Parent commit (@-)      : povouosx f68d1623 | remove goodbye message
 ```
 
 And now our project is up on GitHub!
@@ -96,8 +96,8 @@ Let's fix that:
 
 ```console
 $ jj new trunk
-Working copy now at: vmunwxsk be917d2e (empty) (no description set)
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: vmunwxsk be917d2e (empty) (no description set)
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -134,8 +134,8 @@ Then let's add a description, and push our change to GitHub so we can make a PR:
 
 ```console
 $ jj describe -m "add a comment to main"
-Working copy now at: vmunwxsk 9410db49 add a comment to main
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: vmunwxsk 9410db49 add a comment to main
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 $ jj git push -c @
 Creating bookmark push-vmunwxsksqvk for revision vmunwxsksqvk
 Changes to push to origin:

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -91,7 +91,7 @@ bookmark: trunk@origin [updated] tracked
 $ jj log --limit 3
 ◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
-│ @  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00.000 f853107d
+│ @  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00 f853107d
 ├─╯  (empty) (no description set)
 ◆  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -33,7 +33,8 @@ Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 $ jj bookmark set trunk --allow-backwards
 Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
 $ jj abandon pzkrzopz
-Abandoned commit pzkrzopz fcf669c5 (empty) (no description set)
+Abandoned 1 commits:
+  pzkrzopz fcf669c5 (empty) (no description set)
 $ jj log --limit 2
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -31,7 +31,7 @@ $ jj edit @-
 Working copy  (@) now at: povouosx f68d1623 remove goodbye message
 Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 $ jj bookmark set trunk --allow-backwards
-Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
+Moved 1 bookmarks to povouosx f68d1623 trunk | remove goodbye message
 $ jj abandon pzkrzopz
 Abandoned 1 commits:
   pzkrzopz fcf669c5 (empty) (no description set)
@@ -47,16 +47,25 @@ commit because it is a dangerous operation: if we had pushed `trunk`, things
 would get weird when we try and push now. We've kept it all local, so there's no
 issues with doing this.
 
-Anyway, let's push `trunk` up to GitHub:
+Anyway, let's push `trunk` up to GitHub. A bare `jj git push` won't do it:
+`jj` refuses to create a bookmark on the remote that it doesn't already know
+about, so we have to name it explicitly with `-b`:
 
 ```console
 $ jj git push
+Warning: Refusing to create new remote bookmark trunk@origin
+Hint: Run `jj bookmark track trunk@origin` and try again.
+Nothing changed.
+$ jj git push -b trunk
 Changes to push to origin:
-  Add bookmark trunk to f68d16233bdc
-Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
+  bookmark: trunk [add to f68d16233bdc]
+Warning: The working-copy commit became immutable; a new commit has been created on top of it.
 Working copy  (@) now at: znurnwmk f853107d (empty) (no description set)
-Parent commit (@-)      : povouosx f68d1623 | remove goodbye message
+Parent commit (@-)      : povouosx f68d1623 trunk | remove goodbye message
 ```
+
+Once the bookmark exists on the remote and is tracked, a bare `jj git push` is
+enough for subsequent pushes.
 
 And now our project is up on GitHub!
 
@@ -140,7 +149,7 @@ Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 $ jj git push -c @
 Creating bookmark push-vmunwxsksqvk for revision vmunwxsksqvk
 Changes to push to origin:
-  Add bookmark push-vmunwxsksqvk to 9410db49f9ba
+  bookmark: push-vmunwxsksqvk [add to 9410db49f9ba]
 $ jj log
 @  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk 9410db49
 │  add a comment to main

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -17,9 +17,9 @@ Before we push our commit up, we need to fix our repository:
 
 ```console
 $ jj log --limit 2
-@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 trunk fcf669c5
+@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 trunk fcf669c5
 │  (empty) (no description set)
-◉  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
+○  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
 ```
 
@@ -35,9 +35,9 @@ Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
 $ jj abandon pzkrzopz
 Abandoned commit pzkrzopz fcf669c5 (empty) (no description set)
 $ jj log --limit 2
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
 ```
 
@@ -79,11 +79,11 @@ Let's fetch those changes:
 $ jj git fetch
 bookmark: trunk@origin [updated] tracked
 $ jj log --limit 3
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 │ @  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00.000 f853107d
 ├─╯  (empty) (no description set)
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
+◆  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
 ~
 ```
@@ -141,9 +141,9 @@ Creating bookmark push-vmunwxsksqvk for revision vmunwxsksqvk
 Changes to push to origin:
   Add bookmark push-vmunwxsksqvk to 9410db49f9ba
 $ jj log
-@  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 push-vmunwxsksqvk 9410db49
+@  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk 9410db49
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -60,7 +60,7 @@ Remember, `jj new` won't move any branches, and so if we push, nothing happens:
 
 ```console
 $ jj git push
-Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
+Warning: No bookmarks/tags found in the default push revset: remote_bookmarks(remote=origin)..@
 Nothing changed.
 ```
 
@@ -71,7 +71,7 @@ $ jj bookmark set push-vmunwxsksqvk
 Moved 1 bookmarks to nzsvmmzl ad6b9b14 push-vmunwxsksqvk* | respond to feedback
 $ jj git push
 Changes to push to origin:
-  Move forward bookmark push-vmunwxsksqvk from 9410db49f9ba to ad6b9b149f88
+  bookmark: push-vmunwxsksqvk [move forward from 9410db49f9ba to ad6b9b149f88]
 ```
 
 ![a screenshot of github, showing the new commit below our review](../images/new-pr-commit.png)
@@ -170,7 +170,7 @@ already been "rebased" in a sense. So we can just push:
 ```console
 > jj git push
 Changes to push to origin:
-  Move sideways bookmark push-vmunwxsksqvk from ad6b9b149f88 to 586ea9fd213f
+  bookmark: push-vmunwxsksqvk [move sideways from ad6b9b149f88 to 586ea9fd213f]
 ```
 
 We can see that reflected on GitHub:
@@ -239,7 +239,7 @@ Let's update our branch and push:
 Moved 1 bookmarks to msmntwvo 8f7dcd91 push-vmunwxsksqvk* | add a new function
 > jj git push
 Changes to push to origin:
-  Move sideways bookmark push-vmunwxsksqvk from 586ea9fd213f to 8f7dcd91ecbf
+  bookmark: push-vmunwxsksqvk [move sideways from 586ea9fd213f to 8f7dcd91ecbf]
 ```
 
 We now have two changes again. So what happens when we address our review? Well,
@@ -301,7 +301,7 @@ Parent commit (@-)      : vmunwxsk f6f7dce9 add a comment to main
 Added 0 files, modified 1 files, removed 0 files
 $ jj git push
 Changes to push to origin:
-  Move sideways bookmark push-vmunwxsksqvk from 8f7dcd91ecbf to 752534beb39f
+  bookmark: push-vmunwxsksqvk [move sideways from 8f7dcd91ecbf to 752534beb39f]
 ```
 
 And now we're good! Just that easy. If we didn't want to move `@`, we could have

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -47,11 +47,11 @@ Our change is ready, but one thing is missing:
 
 ```console
 $ jj log
-@  nzsvmmzl steve@steveklabnik.com 2024-03-02 09:22:40.000 -06:00 ad6b9b14
+@  nzsvmmzl steve@steveklabnik.com 2024-03-02 09:22:40 ad6b9b14
 │  respond to feedback
-◉  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 push-vmunwxsksqvk 9410db49
+○  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk 9410db49
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -113,11 +113,11 @@ First, we have to undo what we just did. Here's where we are:
 
 ```console
 > jj log
-@  nzsvmmzl steve@steveklabnik.com 2024-03-02 09:22:40.000 -06:00 push-vmunwxsksqvk ad6b9b14
+@  nzsvmmzl steve@steveklabnik.com 2024-03-02 09:22:40 push-vmunwxsksqvk ad6b9b14
 │  respond to feedback
-◉  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 9410db49
+○  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 9410db49
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -134,9 +134,9 @@ Added 0 files, modified 1 files, removed 0 files
 $ jj abandon nzsvmmzl
 Abandoned commit nzsvmmzl ad6b9b14 push-vmunwxsksqvk@origin | respond to feedback
 $ jj log
-@  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 push-vmunwxsksqvk* 9410db49
+@  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk* 9410db49
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -287,11 +287,11 @@ push:
 
 ```console
 $ jj log
-◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk* 752534be
+○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk* 752534be
 │  add a new function
-@  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+@  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 $ jj next --edit

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -274,7 +274,6 @@ And check our work:
 
 ```console
 $ jj st
- jj st
 Rebased 1 descendant commits onto updated working copy.
 Working copy changes:
 M src/main.rs

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -21,8 +21,8 @@ Let's create a new change:
 
 ```console
 $ jj new -m "respond to feedback"
-Working copy now at: nzsvmmzl 3b663200 (empty) respond to feedback
-Parent commit      : vmunwxsk 9410db49 push-vmunwxsksqvk | add a comment to main
+Working copy  (@) now at: nzsvmmzl 3b663200 (empty) respond to feedback
+Parent commit (@-)      : vmunwxsk 9410db49 push-vmunwxsksqvk | add a comment to main
 ```
 
 And change the text of the comment in `src/main.rs`:
@@ -128,8 +128,8 @@ So let's move the branch backwards, then abandon our new change:
 $ jj bookmark set push-vmunwxsksqvk -r @- --allow-backwards
 Moved 1 bookmarks to vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment to main
 $ jj edit vmunwxsk
-Working copy now at: vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment to main
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment to main
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 $ jj abandon nzsvmmzl
 Abandoned commit nzsvmmzl ad6b9b14 push-vmunwxsksqvk@origin | respond to feedback
@@ -208,8 +208,8 @@ new`:
 
 ```output
 $  jj new -m "add a new function"
-Working copy now at: msmntwvo baaa23e8 (empty) add a new function
-Parent commit      : vmunwxsk 6da57c93 push-vmunwxsksqvk* | add a comment to main
+Working copy  (@) now at: msmntwvo baaa23e8 (empty) add a new function
+Parent commit (@-)      : vmunwxsk 6da57c93 push-vmunwxsksqvk* | add a comment to main
 ```
 
 And then add some new functionality:
@@ -246,8 +246,8 @@ since we're okay with rebasing, we can just edit that commit directly:
 
 ```console
 $ jj edit vmunwxsk
-Working copy now at: vmunwxsk 6da57c93 add a comment to main
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: vmunwxsk 6da57c93 add a comment to main
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -277,8 +277,8 @@ $ jj st
 Rebased 1 descendant commits onto updated working copy
 Working copy changes:
 M src/main.rs
-Working copy : vmunwxsk f6f7dce9 add a comment to main
-Parent commit: ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) : vmunwxsk f6f7dce9 add a comment to main
+Parent commit (@-): ksrmwuon e202b67c trunk | Update Cargo.toml
 ```
 
 There's that automatic rebase again! We don't need to do anything with our
@@ -295,8 +295,8 @@ $ jj log
 │  Update Cargo.toml
 ~
 $ jj next --edit
-Working copy now at: msmntwvo 752534be push-vmunwxsksqvk* | add a new function
-Parent commit      : vmunwxsk f6f7dce9 add a comment to main
+Working copy  (@) now at: msmntwvo 752534be push-vmunwxsksqvk* | add a new function
+Parent commit (@-)      : vmunwxsk f6f7dce9 add a comment to main
 Added 0 files, modified 1 files, removed 0 files
 $ jj git push
 Changes to push to origin:

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -276,7 +276,7 @@ $ jj st
  jj st
 Rebased 1 descendant commits onto updated working copy
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : vmunwxsk f6f7dce9 add a comment to main
 Parent commit: ksrmwuon e202b67c trunk | Update Cargo.toml
 ```

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -132,7 +132,8 @@ Working copy  (@) now at: vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment t
 Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 $ jj abandon nzsvmmzl
-Abandoned commit nzsvmmzl ad6b9b14 push-vmunwxsksqvk@origin | respond to feedback
+Abandoned 1 commits:
+  nzsvmmzl ad6b9b14 push-vmunwxsksqvk@origin | respond to feedback
 $ jj log
 @  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk* 9410db49
 │  add a comment to main
@@ -274,7 +275,7 @@ And check our work:
 ```console
 $ jj st
  jj st
-Rebased 1 descendant commits onto updated working copy
+Rebased 1 descendant commits onto updated working copy.
 Working copy changes:
 M src/main.rs
 Working copy  (@) : vmunwxsk f6f7dce9 add a comment to main


### PR DESCRIPTION
I noticed this really useful repo hadn't had any updates since Feb, so I asked Claude to update it for 0.44, and confirm all the changes against the latest homebrew jj in a temp repo.

How does it look? Done on a colocated jj repo so really interesting to see it in action!

There’s a more comprehensive update in https://github.com/steveklabnik/jujutsu-tutorial/pull/114 that sits on top of this PR.