### PR TITLE
Expanding the tutorial

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 book
+.DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repository instructions
+
+Before doing any work in this repository, read `CLAUDE.md` completely and
+follow its project guidance.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,1 @@
-# Repository instructions
-
-Before doing any work in this repository, read `CLAUDE.md` completely and
-follow its project guidance.
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ permission for that command. Read-only `git log`/`git status` are fine, but pref
 **Plain Git (`jj st` fails):** use normal `git` commands.
 
 Confirm `jj --version` matches the version the book documents in
-`src/hello-world/how-to-install.md` (currently 0.44.0). Flag any mismatch —
+`src/hello-world/how-to-install.md` (currently 0.45.1). Flag any mismatch —
 behaviour and prose may diverge.
 
 ## Build and test gate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+An mdBook tutorial for Jujutsu. Prose lives in `src/`; `book.toml` is the config.
+Built output goes to `book/` and is not committed.
+
+## Version control
+
+Run `jj st` at the start of each session — this may be a jj repo on one machine
+and plain Git on another.
+
+**IMPORTANT:** if this is a jj repo, manage it with jj, not Git.
+
+**jj repo (`jj st` succeeds):** use jj commands only. Do not run state-modifying
+`git` commands (`commit`, `push`, `rebase`, `reset`, `branch`, …) without explicit
+permission for that command. Read-only `git log`/`git status` are fine, but prefer
+`jj log`/`jj st`. Push with `jj git push` — it forces with lease natively, so no
+`git push --force`.
+
+**Plain Git (`jj st` fails):** use normal `git` commands.
+
+Confirm `jj --version` matches the version the book documents in
+`src/hello-world/how-to-install.md` (currently 0.44.0). Flag any mismatch —
+behaviour and prose may diverge.
+
+## Build and test gate
+
+jj snapshots the working copy into `@` automatically — there is no Git-style
+commit step. So the gate is finishing a change: before you move off `@` with
+`jj new` or `jj commit`, or publish with `jj git push`, the book must build and
+test clean:
+
+```
+mdbook build
+mdbook test
+```
+
+Don't call a change done until both pass.
+
+After finishing and pushing a change, run `jj new` to leave `@` as a fresh empty
+change. This keeps `describe`d work from being confused with new edits — the
+current change is always either empty or clearly in progress.
+
+## Writing
+
+Match the voice of the existing prose — a relaxed, first-person walkthrough.
+Read nearby chapters before adding text so new sections read as part of the same
+work.
+
+Use the original prose at change ID `wtzppvkn` (`main@origin`), commit ID
+`8c4b3784`, as the reference point for the book's tone. The change ID is useful
+with `jj`, while the commit ID identifies the same revision through Git. Compare
+new chapters directly with that revision rather than inferring the voice from
+later additions.
+
+Use `we` and `our` while walking through examples with the reader, and use `I`
+for personal preferences or judgments. Introduce a concrete situation before
+the command that solves it, then explain the output as the next step in the
+same story. Prefer patient transitions such as "Let's see" and "You may have
+noticed" over clipped, reference-manual prose. Keep examples continuous with
+nearby chapters when possible.
+
+Avoid slogans, punchy fragments, and glib comparisons with Git. Comparisons are
+useful when they explain a specific difference in behavior, but the tutorial's
+voice should stay curious and conversational rather than adversarial. Wrap prose
+at about 80 columns, following the surrounding Markdown.
+
+**IMPORTANT:** this is a tutorial — confirm everything against jj in practice.
+Describe jj's real behaviour, not assumed behaviour: run any command in a
+disposable jj repo (`jj git init /tmp/jj-scratch` or similar) and match the prose
+to its actual output before documenting it. Never use this repo's own history as a
+test bed.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -32,12 +32,14 @@
     - [Responding to pull request feedback](sharing-code/updating-prs.md)
     - [Tagging a release with `jj tag`](sharing-code/tags.md)
     - [Updating trunk from upstream](sharing-code/updating-trunk.md)
+    - [Working with a fork](sharing-code/forks.md)
     - [Using jj with Gerrit](sharing-code/gerrit.md)
 
 - [More advanced workflows](advanced/more-advanced-workflows.md)
     - [Working on all of your branches simultaneously](advanced/simultaneous-edits.md)
     - [Stacked pull requests](advanced/stacked-prs.md)
     - [Copying a change with `jj duplicate`](advanced/duplicating-changes.md)
+    - [Running formatters with `jj fix`](advanced/fixing-files.md)
     - [Workspaces](advanced/workspaces.md)
     - [Non-colocated repositories](advanced/non-colocated-repos.md)
 
@@ -46,6 +48,7 @@
     - [The operation log](fixing-problems/the-operation-log.md)
     - [Watching a change evolve with `jj evolog`](fixing-problems/the-evolog.md)
     - [Throwing work away on purpose](fixing-problems/reverting-changes.md)
+    - [Finding the commit that broke it with `jj bisect`](fixing-problems/bisecting.md)
 
 - [Customizing your experience](customization/customizing-your-experience.md)
     - [Configuring `jj`](customization/configuring-jj.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -38,7 +38,7 @@
     - [Undoing mistakes]()
     - [Reverting changes]()
     - [The Operation Log]()
-    - [The obslog]()
+    - [The evolog]()
 
 - [Customizing your experience]()
     - [Configuring `jj`]()

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -50,6 +50,7 @@
     - [Undoing mistakes with `jj undo`](fixing-problems/undoing-mistakes.md)
     - [The operation log](fixing-problems/the-operation-log.md)
     - [Watching a change evolve with `jj evolog`](fixing-problems/the-evolog.md)
+    - [Untangling divergent changes](fixing-problems/divergent-changes.md)
     - [Throwing work away on purpose](fixing-problems/reverting-changes.md)
     - [Finding the commit that broke it with `jj bisect`](fixing-problems/bisecting.md)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -18,6 +18,7 @@
     - [The Edit Workflow](real-world-workflows/the-edit-workflow.md)
     - [Splitting a change with `jj split`](real-world-workflows/splitting-changes.md)
     - [Absorbing changes with `jj absorb`](real-world-workflows/absorbing-changes.md)
+    - [Editing a commit's diff with `jj diffedit`](real-world-workflows/editing-a-commit.md)
 
 - [Branching, merging, and conflicts](branching-merging-and-conflicts/intro.md)
     - [What anonymous branches are, and how to use them](branching-merging-and-conflicts/anonymous-branches.md)
@@ -40,7 +41,9 @@
     - [Stacked pull requests](advanced/stacked-prs.md)
     - [Copying a change with `jj duplicate`](advanced/duplicating-changes.md)
     - [Running formatters with `jj fix`](advanced/fixing-files.md)
+    - [Running a command across revisions with `jj run`](advanced/running-commands.md)
     - [Workspaces](advanced/workspaces.md)
+    - [Working alongside `git`](advanced/working-alongside-git.md)
     - [Non-colocated repositories](advanced/non-colocated-repos.md)
 
 - [Fixing Problems](fixing-problems/intro.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -14,6 +14,7 @@
 - [Real-world workflows](real-world-workflows/intro.md)
     - [The Squash Workflow](real-world-workflows/the-squash-workflow.md)
     - [The Edit Workflow](real-world-workflows/the-edit-workflow.md)
+    - [Splitting a change with `jj split`](real-world-workflows/splitting-changes.md)
 
 - [Branching, merging, and conflicts](branching-merging-and-conflicts/intro.md)
     - [What anonymous branches are, and how to use them](branching-merging-and-conflicts/anonymous-branches.md)
@@ -31,7 +32,7 @@
 
 - [More advanced workflows](advanced/more-advanced-workflows.md)
     - [Working on all of your branches simultaneously](advanced/simultaneous-edits.md)
-    - [Stacked PRs]()
+    - [Stacked pull requests](advanced/stacked-prs.md)
     - [Workspaces]()
     - [Colocated Repositories]()
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -25,6 +25,7 @@
     - [Using named branches in jj](sharing-code/named-branches.md)
     - [Working with remotes, e.g., GitHub](sharing-code/remotes.md)
     - [Responding to pull request feedback](sharing-code/updating-prs.md)
+    - [Tagging a release with `jj tag`](sharing-code/tags.md)
     - [Updating trunk from upstream]()
     - [Using jj with Gerrit](sharing-code/gerrit.md)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -35,11 +35,11 @@
     - [Workspaces]()
     - [Colocated Repositories]()
 
-- [Fixing Problems]()
-    - [Undoing mistakes]()
-    - [Reverting changes]()
-    - [The Operation Log]()
-    - [The evolog]()
+- [Fixing Problems](fixing-problems/intro.md)
+    - [Undoing mistakes with `jj undo`](fixing-problems/undoing-mistakes.md)
+    - [The operation log](fixing-problems/the-operation-log.md)
+    - [Watching a change evolve with `jj evolog`](fixing-problems/the-evolog.md)
+    - [Throwing work away on purpose](fixing-problems/reverting-changes.md)
 
 - [Customizing your experience]()
     - [Configuring `jj`]()

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -27,14 +27,14 @@
     - [Working with remotes, e.g., GitHub](sharing-code/remotes.md)
     - [Responding to pull request feedback](sharing-code/updating-prs.md)
     - [Tagging a release with `jj tag`](sharing-code/tags.md)
-    - [Updating trunk from upstream]()
+    - [Updating trunk from upstream](sharing-code/updating-trunk.md)
     - [Using jj with Gerrit](sharing-code/gerrit.md)
 
 - [More advanced workflows](advanced/more-advanced-workflows.md)
     - [Working on all of your branches simultaneously](advanced/simultaneous-edits.md)
     - [Stacked pull requests](advanced/stacked-prs.md)
-    - [Workspaces]()
-    - [Colocated Repositories]()
+    - [Workspaces](advanced/workspaces.md)
+    - [Non-colocated repositories](advanced/non-colocated-repos.md)
 
 - [Fixing Problems](fixing-problems/intro.md)
     - [Undoing mistakes with `jj undo`](fixing-problems/undoing-mistakes.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -15,6 +15,7 @@
     - [The Squash Workflow](real-world-workflows/the-squash-workflow.md)
     - [The Edit Workflow](real-world-workflows/the-edit-workflow.md)
     - [Splitting a change with `jj split`](real-world-workflows/splitting-changes.md)
+    - [Absorbing changes with `jj absorb`](real-world-workflows/absorbing-changes.md)
 
 - [Branching, merging, and conflicts](branching-merging-and-conflicts/intro.md)
     - [What anonymous branches are, and how to use them](branching-merging-and-conflicts/anonymous-branches.md)
@@ -42,6 +43,6 @@
     - [Watching a change evolve with `jj evolog`](fixing-problems/the-evolog.md)
     - [Throwing work away on purpose](fixing-problems/reverting-changes.md)
 
-- [Customizing your experience]()
-    - [Configuring `jj`]()
+- [Customizing your experience](customization/customizing-your-experience.md)
+    - [Configuring `jj`](customization/configuring-jj.md)
     - [Customizing the output of various `jj` commands with templates](customization/templates.md)

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -10,6 +10,8 @@
     - [Using `jj describe` to describe our commits in a human-friendly way](hello-world/describing-commits.md)
     - [Using `jj new` to create new changes](hello-world/creating-new-changes.md)
     - [Viewing the contents of your repository with `jj log`](hello-world/viewing-contents.md)
+    - [Seeing what changed with `jj diff` and `jj show`](hello-world/viewing-changes.md)
+    - [Which files `jj` tracks](hello-world/tracking-files.md)
     - [A recap and some thoughts](hello-world/recap.md)
 - [Real-world workflows](real-world-workflows/intro.md)
     - [The Squash Workflow](real-world-workflows/the-squash-workflow.md)
@@ -22,6 +24,7 @@
     - [Figuring out where our changes are with revsets](branching-merging-and-conflicts/revsets.md)
     - [Merging anonymous branches](branching-merging-and-conflicts/merging.md)
     - [Dealing with conflicts](branching-merging-and-conflicts/conflicts.md)
+    - [Resolving conflicts with `jj resolve`](branching-merging-and-conflicts/resolving-conflicts.md)
 
 - [Sharing your code with others](sharing-code/intro.md)
     - [Using named branches in jj](sharing-code/named-branches.md)
@@ -34,6 +37,7 @@
 - [More advanced workflows](advanced/more-advanced-workflows.md)
     - [Working on all of your branches simultaneously](advanced/simultaneous-edits.md)
     - [Stacked pull requests](advanced/stacked-prs.md)
+    - [Copying a change with `jj duplicate`](advanced/duplicating-changes.md)
     - [Workspaces](advanced/workspaces.md)
     - [Non-colocated repositories](advanced/non-colocated-repos.md)
 

--- a/src/advanced/duplicating-changes.md
+++ b/src/advanced/duplicating-changes.md
@@ -1,0 +1,81 @@
+# Copying a change with `jj duplicate`
+
+Every history command we've used so far has *moved* work. `jj rebase` moves a
+change to a new parent, `jj squash` moves it into another commit, and
+`jj absorb` moves hunks around. Sometimes we want to copy a change instead.
+That's what `jj duplicate` does: the original stays where it is, and a second,
+independent change appears somewhere else.
+
+This is the equivalent of `git cherry-pick`. A common example is a fix that
+landed on our main line of work and is also needed on a release branch:
+
+```console
+$ jj log
+@  qrmutqws steve@steveklabnik.com 2024-03-27 10:30:47 5e653078
+│  fix a bug
+│ ○  myvqszlv steve@steveklabnik.com 2024-03-27 10:30:47 c25044fc
+├─╯  release prep
+○  unrvswsv steve@steveklabnik.com 2024-03-27 10:30:47 ecc089fe
+│  initial
+◆  zzzzzzzz root() 00000000
+```
+
+```console
+$ jj duplicate qrmutqws --onto myvqszlv
+Duplicated 5e653078ccee as mzrozlul 5b488518 fix a bug
+```
+
+```console
+$ jj log
+@  qrmutqws steve@steveklabnik.com 2024-03-27 10:30:47 5e653078
+│  fix a bug
+│ ○  mzrozlul steve@steveklabnik.com 2024-03-27 10:30:47 5b488518
+│ │  fix a bug
+│ ○  myvqszlv steve@steveklabnik.com 2024-03-27 10:30:47 c25044fc
+├─╯  release prep
+○  unrvswsv steve@steveklabnik.com 2024-03-27 10:30:47 ecc089fe
+│  initial
+◆  zzzzzzzz root() 00000000
+```
+
+Excellent. The fix is now in both places, and our working copy never moved.
+
+## The copy is a different change
+
+Let's look closely at the two IDs. The original is `qrmutqws`; the copy is
+`mzrozlul`. Same description, same contents, different change.
+
+This is the important distinction between `duplicate` and `rebase`. A rebased
+commit keeps its change ID because it's still the same change in a new place. A
+duplicated commit gets a new one because there are now two independent changes.
+If we edit one, the other doesn't follow.
+
+It also means the two copies will be pushed as separate commits and reviewed
+separately, which is what you want for a backport, and is exactly what a
+`git cherry-pick` does.
+
+## Where the copy lands
+
+We used `--onto` to put the copy on a destination. The same `-A` and `-B` flags
+we saw with `jj rebase` work here too. They let us insert the copy into the
+middle of a stack rather than on top of something:
+
+```console
+$ jj duplicate qrmutqws -A myvqszlv
+```
+
+With no destination at all, the copy becomes a sibling of the original and
+shares its parents. We can use that form when we want to try two versions of the
+same idea side by side and keep both.
+
+You can duplicate several changes at once by naming a revset, which is how you
+backport a whole feature rather than one commit.
+
+## When not to
+
+If we find ourselves duplicating the same fix onto several release branches
+every time, a merge may be a better fit. Duplicating makes sense when the
+destination genuinely needs its own version of the change, such as a backport
+that will be maintained separately or an experiment we want two versions of.
+If we only want to move a change, `jj rebase` leaves us with one copy to keep
+track of.

--- a/src/advanced/fixing-files.md
+++ b/src/advanced/fixing-files.md
@@ -62,6 +62,10 @@ $ jj fix -s 'all()'
 Error: The root commit 000000000000 is immutable
 ```
 
+That's a purely local repository talking; in a repository with a pushed trunk,
+the refusal names the trunk commit instead. Either way, nothing shared gets
+rewritten.
+
 If you'd rather it defaulted to something else, `revsets.fix` in your config
 sets the default scope.
 

--- a/src/advanced/fixing-files.md
+++ b/src/advanced/fixing-files.md
@@ -1,0 +1,86 @@
+# Running formatters with `jj fix`
+
+In `git`, we may reach for a pre-commit hook to run a formatter. `jj` doesn't
+run `git` hooks, but it does have a different approach: `jj fix` can run a
+formatter over a whole stack of commits.
+
+We configure the command to run and the files it applies to:
+
+```toml
+[fix.tools.rustfmt]
+command = ["rustfmt", "--emit", "stdout"]
+patterns = ["glob:**/*.rs"]
+```
+
+The contract is simple: our tool reads a file on stdin, writes the fixed version
+to stdout, and `jj` puts the result back. Any formatter that can do that works,
+and we can configure as many as we like. Each `[fix.tools.<name>]` section gets
+its own `patterns`.
+
+Then:
+
+```console
+$ jj fix
+Fixed 2 commits of 4 checked.
+Working copy  (@) now at: kvrxwpqm 1a7d451e (empty) add docs
+Parent commit (@-)      : plzxxqzu 55ac427d (no description set)
+```
+
+`jj` examined four commits and found two that actually needed changing. It
+rewrote both in place and rebased everything downstream, just like the other
+history-editing commands we've used.
+
+## What gets fixed
+
+With no arguments, `jj fix` covers `reachable(@, mutable())`: our working copy
+and every mutable commit connected to it. Remember, "mutable" means `jj` permits
+us to rewrite the commit; it doesn't mean the commit is unpushed. In particular,
+commits on a tracked remote bookmark stay mutable by default so that pull
+request stacks can be rewritten. Bare `jj fix` can therefore touch work that's
+already under review, but it won't touch immutable commits such as trunk.
+
+This is what makes it different from a hook. A formatter run as a
+pre-commit hook leaves every earlier commit in the stack unformatted, so a
+stack of five commits gets five rounds of "fix formatting" noise, or one
+formatting commit at the end that touches files the other four introduced.
+`jj fix` reformats all five as if you'd had the formatter on the whole time.
+
+We can use `-s` to narrow or widen that set:
+
+```console
+$ jj fix -s @
+$ jj fix -s 'mutable()'
+```
+
+Naming a revision fixes that revision *and its descendants*, because changing a
+file in the middle of a stack means everything above needs rebasing anyway. And
+the immutable rule still applies — asking for `all()` gets you a refusal rather
+than a rewrite of trunk:
+
+```console
+$ jj fix -s 'all()'
+Error: The root commit 000000000000 is immutable
+```
+
+If you'd rather it defaulted to something else, `revsets.fix` in your config
+sets the default scope.
+
+## When to run it
+
+`jj fix` rewrites commits, so every commit it touches gets a new commit ID. For
+work we haven't pushed, that doesn't matter. On a branch someone is reviewing,
+it means the next push will rewrite the remote commits, and the review tool may
+show the formatting changes again. I prefer to run it before pushing when I
+can.
+
+It may run your formatter once for every distinct version of a file in the
+stack, which on a long stack is not free. Identical file contents are
+deduplicated, but formatting history still costs more than formatting only the
+tip. That's the price of the history coming out clean.
+
+## The other use
+
+Formatting is the obvious case, but we can use the same mechanism for any tool
+that reads and writes a file this way. A `sed` script or a purpose-built codemod
+works too. `jj fix` lets us apply it consistently across a stack rather than
+only at the tip.

--- a/src/advanced/more-advanced-workflows.md
+++ b/src/advanced/more-advanced-workflows.md
@@ -3,11 +3,12 @@
 The workflows we've seen in `jj` are different from `git` in the best ways. As we
 get a bit more advanced, there are some very impressive possibilities yet to
 see. This section will also address an interesting aspect of interoperability
-between `jj` and `git`: colocated repositories.
+between `jj` and `git`: what happens when you take the `git` repository out of
+sight.
 
 Here's what we're going to learn:
 
 * Working on all your branches simultaneously
 * A pull request workflow called "Stacked PRs"
 * Workspaces that let you have multiple local checkouts
-* Using `git` and `jj` at the same time with colocated repositories
+* Non-colocated repositories, and where the line between `jj` and `git` sits

--- a/src/advanced/more-advanced-workflows.md
+++ b/src/advanced/more-advanced-workflows.md
@@ -11,5 +11,6 @@ Here's what we're going to learn:
 * Working on all your branches simultaneously
 * A pull request workflow called "Stacked PRs"
 * Copying a change to another branch with `jj duplicate`
+* Running formatters across a whole stack with `jj fix`
 * Workspaces that let you have multiple local checkouts
 * Non-colocated repositories, and where the line between `jj` and `git` sits

--- a/src/advanced/more-advanced-workflows.md
+++ b/src/advanced/more-advanced-workflows.md
@@ -12,5 +12,7 @@ Here's what we're going to learn:
 * A pull request workflow called "Stacked PRs"
 * Copying a change to another branch with `jj duplicate`
 * Running formatters across a whole stack with `jj fix`
+* Running any command across a stack with `jj run`
 * Workspaces that let you have multiple local checkouts
+* The rules of working alongside `git` in the default colocated repository
 * Non-colocated repositories, and where the line between `jj` and `git` sits

--- a/src/advanced/more-advanced-workflows.md
+++ b/src/advanced/more-advanced-workflows.md
@@ -10,5 +10,6 @@ Here's what we're going to learn:
 
 * Working on all your branches simultaneously
 * A pull request workflow called "Stacked PRs"
+* Copying a change to another branch with `jj duplicate`
 * Workspaces that let you have multiple local checkouts
 * Non-colocated repositories, and where the line between `jj` and `git` sits

--- a/src/advanced/non-colocated-repos.md
+++ b/src/advanced/non-colocated-repos.md
@@ -1,0 +1,171 @@
+# Non-colocated repositories
+
+Every repository in this book has been a colocated one: a `.jj` directory and a
+real `.git` directory over a single working copy, which is what `jj git init`
+gives you and what chapter one described. `git` can see everything you do, and
+`gh`, your editor, and any other tool that reads `.git` work without knowing
+`jj` exists.
+
+There's a second arrangement, and it's worth knowing about even if you never
+switch to it, because it shows you where the line between `jj` and `git`
+actually sits.
+
+```console
+$ jj git init --no-colocate
+Initialized repo in "."
+
+$ ls -a
+.
+..
+.jj
+```
+
+One directory. No `.git`:
+
+```console
+$ git status
+fatal: not a git repository (or any of the parent directories): .git
+```
+
+## The `git` repository is still there
+
+`jj` is still backed by `git`. The store just moved inside `.jj`, where nothing
+finds it by accident:
+
+```console
+$ jj git colocation status
+Workspace is currently not colocated with Git.
+Last imported/exported Git HEAD: (none)
+Hint: To enable colocation, run: `jj git colocation enable`
+
+$ jj git root
+/home/steve/src/my-project/.jj/repo/store/git
+```
+
+Point `git` at that path and it works normally:
+
+```console
+$ GIT_DIR=$(jj git root) GIT_WORK_TREE=$(jj workspace root) git status
+```
+
+`gh` is the same story — `GIT_DIR=$(jj git root) gh pr list`. Nothing is
+unavailable. It just has to be asked for.
+
+Remotes are entirely unaffected. `jj git fetch`, `jj git push`, and
+`jj git clone --no-colocate` behave exactly as they do in a colocated
+repository, because they talk to the store directly and never needed a
+top-level `.git` in the first place.
+
+## Exports stop being automatic
+
+Here's the difference that matters in practice. A colocated repository imports
+`git` state and exports its own on *every* command. That's what keeps the two
+views in step. Without colocation there's nothing to stay in step with, so `jj`
+doesn't bother:
+
+```console
+$ jj bookmark create second -r @-
+Created 1 bookmarks pointing to okxrzpsx 66ac5baa second | first
+
+$ GIT_DIR=$(jj git root) git branch
+  feature
+```
+
+The bookmark exists in `jj` and the `git` store hasn't heard about it. Run more
+`jj` commands and it still hasn't. You have to say so:
+
+```console
+$ jj git export
+
+$ GIT_DIR=$(jj git root) git branch
+  feature
+  second
+```
+
+`jj git import` goes the other way. In a colocated repository you rarely type
+either of these; here they're how the `git` view gets updated at all. If you're
+reaching for `git` in a non-colocated repository often enough to keep exporting,
+that's an argument for colocating.
+
+## Nothing to explain to `git`
+
+The other consequence is a nuisance you stop having.
+
+In a colocated repository, `git`'s `HEAD` is detached and points at a *parent*
+of `@`, because the working copy being a commit is an idea `git` can't state.
+So after `jj edit` on a finished commit, `git status` reports its already
+recorded patch as an uncommitted modification:
+
+```console
+$ git status --short
+ M f.txt
+```
+
+That's `git` accurately describing the gap between `HEAD` and the files, and
+it's harmless — but it surprises people, and some editors and pre-commit tooling
+behave oddly around a tree they think is dirty. In a non-colocated repository
+nothing is looking, so nothing is confused.
+
+## Choosing
+
+Colocation buys you an ecosystem for free and asks for one discipline in return:
+let `jj` do the mutating. Read-only `git` commands are fine and often the
+quickest way to see something. Mutating ones — `git commit`, `git rebase`,
+moving a branch — can be imported afterwards, but they race `jj`'s own
+import and export if run concurrently, they can't be handed over half-finished,
+and moving a bookmark in both tools gets you the `name??` conflict from an
+earlier chapter.
+
+Non-colocation enforces that discipline instead of asking for it. There's no
+`.git` for an editor plugin to act on, no `git commit` typed out of habit, no
+script that discovers a repository you didn't mean it to find. Some people want
+that, particularly on a machine running tooling they don't control.
+
+Most people, most of the time, want the default. If you work on GitHub and use
+`gh`, colocation costs you nothing and saves you a prefix on every command.
+Either way you're not committed:
+
+```console
+$ jj git colocation disable
+Workspace successfully converted into a non-colocated Jujutsu/Git workspace.
+```
+
+`jj git colocation enable` converts back, and `git.colocate = false` in your
+config makes `--no-colocate` the default for new repositories.
+
+## Native repositories
+
+Both arrangements keep your commits in a `git` repository. The only difference
+is where it sits and who else can see it. You can confirm that in any repository
+you have:
+
+```console
+$ jj util backend name
+git
+```
+
+`jj` does have a storage format of its own, and chapter one mentioned it in
+passing. It is still a work in progress, and `jj` 0.44.0 does not provide a
+command for creating a repository that uses it. For now, both arrangements in
+this chapter use the `git` backend; colocation only decides whether the Git
+repository is exposed at the top of our working copy.
+
+## What `git` gives up either way
+
+A few `git` features aren't implemented by `jj` at all, colocated or not:
+
+* **Submodules** are not materialized in the working copy. They survive, but
+  `jj` won't check them out or update them.
+* **Git LFS** is unsupported. Pointer files are ordinary files.
+* **`git` hooks don't run.** No pre-commit, no pre-push. Use `jj fix` or CI.
+* **`.gitattributes` is ignored** — no clean/smudge filters, no line-ending
+  normalization.
+* **Annotated tags** can be read and checked out, but not created.
+* **`git config` is mostly ignored**, except remote configuration and
+  `core.excludesFile`.
+* **Shallow clones** work, but deepening one doesn't; partial clone is
+  unsupported.
+
+In a colocated repository, `jj` also puts an ignore file inside `.jj` so a
+`git add -A` does not add its internal state. We don't need to add `.jj/` to the
+project's own `.gitignore`.

--- a/src/advanced/non-colocated-repos.md
+++ b/src/advanced/non-colocated-repos.md
@@ -1,14 +1,12 @@
 # Non-colocated repositories
 
-Every repository in this book has been a colocated one: a `.jj` directory and a
-real `.git` directory over a single working copy, which is what `jj git init`
-gives you and what chapter one described. `git` can see everything you do, and
-`gh`, your editor, and any other tool that reads `.git` work without knowing
-`jj` exists.
+Every repository in this book has been a colocated one. As we saw in chapter
+one, `jj git init` gives us a `.jj` directory and a real `.git` directory over
+the same working copy. `git` can see everything we do, and tools such as `gh`
+and our editor can work without knowing that `jj` exists.
 
-There's a second arrangement, and it's worth knowing about even if you never
-switch to it, because it shows you where the line between `jj` and `git`
-actually sits.
+There's a second arrangement. Even if we never switch to it, looking at it will
+help us understand where the line between `jj` and `git` actually sits.
 
 ```console
 $ jj git init --no-colocate
@@ -20,7 +18,7 @@ $ ls -a
 .jj
 ```
 
-One directory. No `.git`:
+Now we have one directory and no `.git`:
 
 ```console
 $ git status
@@ -29,8 +27,8 @@ fatal: not a git repository (or any of the parent directories): .git
 
 ## The `git` repository is still there
 
-`jj` is still backed by `git`. The store just moved inside `.jj`, where nothing
-finds it by accident:
+We are still using the `git` backend. Its store has moved inside `.jj`, where
+other tools won't find it by accident:
 
 ```console
 $ jj git colocation status
@@ -42,7 +40,7 @@ $ jj git root
 /home/steve/src/my-project/.jj/repo/store/git
 ```
 
-Point `git` at that path and it works normally:
+If we point `git` at that path explicitly, it works normally:
 
 ```console
 $ GIT_DIR=$(jj git root) GIT_WORK_TREE=$(jj workspace root) git status
@@ -51,17 +49,17 @@ $ GIT_DIR=$(jj git root) GIT_WORK_TREE=$(jj workspace root) git status
 `gh` is the same story — `GIT_DIR=$(jj git root) gh pr list`. Nothing is
 unavailable. It just has to be asked for.
 
-Remotes are entirely unaffected. `jj git fetch`, `jj git push`, and
-`jj git clone --no-colocate` behave exactly as they do in a colocated
-repository, because they talk to the store directly and never needed a
-top-level `.git` in the first place.
+Remotes are entirely unaffected. We can use `jj git fetch`, `jj git push`, and
+`jj git clone --no-colocate` exactly as we did in a colocated repository. These
+commands talk to the store directly, so they never needed a top-level `.git` in
+the first place.
 
 ## Exports stop being automatic
 
-Here's the difference that matters in practice. A colocated repository imports
-`git` state and exports its own on *every* command. That's what keeps the two
-views in step. Without colocation there's nothing to stay in step with, so `jj`
-doesn't bother:
+Here's the difference that matters in practice. Our colocated repositories
+imported `git` state and exported their own on *every* command. That's what kept
+the two views in step. Without colocation, there is no top-level `git` view to
+keep in step, so `jj` doesn't do that automatically:
 
 ```console
 $ jj bookmark create second -r @-
@@ -82,14 +80,14 @@ $ GIT_DIR=$(jj git root) git branch
   second
 ```
 
-`jj git import` goes the other way. In a colocated repository you rarely type
-either of these; here they're how the `git` view gets updated at all. If you're
-reaching for `git` in a non-colocated repository often enough to keep exporting,
-that's an argument for colocating.
+`jj git import` goes the other way. In a colocated repository, we rarely need
+either command. Here, they are how we update the `git` view at all. If we find
+ourselves exporting every few minutes, that's a good sign that colocation would
+fit our workflow better.
 
-## Nothing to explain to `git`
+## Keeping `git` out of the working copy
 
-The other consequence is a nuisance you stop having.
+This also changes what `git`-based tools see.
 
 In a colocated repository, `git`'s `HEAD` is detached and points at a *parent*
 of `@`, because the working copy being a commit is an idea `git` can't state.
@@ -106,24 +104,24 @@ it's harmless — but it surprises people, and some editors and pre-commit tooli
 behave oddly around a tree they think is dirty. In a non-colocated repository
 nothing is looking, so nothing is confused.
 
-## Choosing
+## Choosing between them
 
-Colocation buys you an ecosystem for free and asks for one discipline in return:
-let `jj` do the mutating. Read-only `git` commands are fine and often the
-quickest way to see something. Mutating ones — `git commit`, `git rebase`,
-moving a branch — can be imported afterwards, but they race `jj`'s own
-import and export if run concurrently, they can't be handed over half-finished,
-and moving a bookmark in both tools gets you the `name??` conflict from an
-earlier chapter.
+Colocation gives us access to the `git` ecosystem, with one important rule: let
+`jj` make the changes. Read-only `git` commands are fine and are often the
+quickest way to inspect something. Mutating commands such as `git commit` and
+`git rebase` can be imported afterwards, but they can race `jj`'s own import and
+export if run concurrently. `jj` also can't take over one of these operations
+halfway through, and moving a bookmark in both tools can produce the `name??`
+conflict from an earlier chapter.
 
 Non-colocation enforces that discipline instead of asking for it. There's no
 `.git` for an editor plugin to act on, no `git commit` typed out of habit, no
 script that discovers a repository you didn't mean it to find. Some people want
 that, particularly on a machine running tooling they don't control.
 
-Most people, most of the time, want the default. If you work on GitHub and use
-`gh`, colocation costs you nothing and saves you a prefix on every command.
-Either way you're not committed:
+I think the default is right for most people. If we work on GitHub and use
+`gh`, colocation lets those tools work normally. We aren't locked into either
+choice:
 
 ```console
 $ jj git colocation disable
@@ -135,9 +133,8 @@ config makes `--no-colocate` the default for new repositories.
 
 ## Native repositories
 
-Both arrangements keep your commits in a `git` repository. The only difference
-is where it sits and who else can see it. You can confirm that in any repository
-you have:
+Both arrangements keep our commits in a `git` repository. The only difference
+is where it sits and who else can see it. We can confirm that in any repository:
 
 ```console
 $ jj util backend name
@@ -150,14 +147,17 @@ command for creating a repository that uses it. For now, both arrangements in
 this chapter use the `git` backend; colocation only decides whether the Git
 repository is exposed at the top of our working copy.
 
-## What `git` gives up either way
+## Unsupported `git` features
 
-A few `git` features aren't implemented by `jj` at all, colocated or not:
+A few `git` features aren't implemented by `jj`, whether or not the repository
+is colocated:
 
 * **Submodules** are not materialized in the working copy. They survive, but
   `jj` won't check them out or update them.
 * **Git LFS** is unsupported. Pointer files are ordinary files.
-* **`git` hooks don't run.** No pre-commit, no pre-push. Use `jj fix` or CI.
+* **`git` hooks don't run.** No pre-commit, no pre-push. `jj fix`, which we
+  covered a couple of chapters ago, replaces the formatting ones; CI has to
+  cover the rest.
 * **`.gitattributes` is ignored** — no clean/smudge filters, no line-ending
   normalization.
 * **Annotated tags** can be read and checked out, but not created.

--- a/src/advanced/non-colocated-repos.md
+++ b/src/advanced/non-colocated-repos.md
@@ -6,7 +6,10 @@ the same working copy. `git` can see everything we do, and tools such as `gh`
 and our editor can work without knowing that `jj` exists.
 
 There's a second arrangement. Even if we never switch to it, looking at it will
-help us understand where the line between `jj` and `git` actually sits.
+help us understand where the line between `jj` and `git` actually sits. This is
+a specialized alternative rather than another default: we should start with a
+colocated repository unless keeping Git-aware tools out is important to our
+workflow.
 
 ```console
 $ jj git init --no-colocate
@@ -142,9 +145,10 @@ git
 ```
 
 `jj` does have a storage format of its own, and chapter one mentioned it in
-passing. It is still a work in progress, and `jj` 0.44.0 does not provide a
-command for creating a repository that uses it. For now, both arrangements in
-this chapter use the `git` backend; colocation only decides whether the Git
+passing. Its `SimpleBackend` is a proof of concept, and `jj` 0.44.0 does not
+provide a command for creating a repository that uses it. It isn't a third
+everyday choice for us to consider. For normal use, both arrangements in this
+chapter use the `git` backend; colocation only decides whether the Git
 repository is exposed at the top of our working copy.
 
 ## Unsupported `git` features

--- a/src/advanced/non-colocated-repos.md
+++ b/src/advanced/non-colocated-repos.md
@@ -145,7 +145,7 @@ git
 ```
 
 `jj` does have a storage format of its own, and chapter one mentioned it in
-passing. Its `SimpleBackend` is a proof of concept, and `jj` 0.44.0 does not
+passing. Its `SimpleBackend` is a proof of concept, and `jj` 0.45.1 does not
 provide a command for creating a repository that uses it. It isn't a third
 everyday choice for us to consider. For normal use, both arrangements in this
 chapter use the `git` backend; colocation only decides whether the Git

--- a/src/advanced/running-commands.md
+++ b/src/advanced/running-commands.md
@@ -1,0 +1,80 @@
+# Running a command across revisions with `jj run`
+
+`jj fix` pipes each file through a formatter. Sometimes we want to run a more
+general command against several revisions. `jj run` checks out every revision
+we name in an isolated working copy, runs a command there, and, by default,
+amends the revision with whatever the command changed. Descendants rebase as
+usual, so we can apply one command to a whole stack.
+
+There are two jobs I find useful here, and they want opposite flags.
+
+## Testing a whole stack
+
+First, we can run the tests against every commit in a stack and find out which
+one is broken. We don't want a test to rewrite anything, so we'll pass
+`--ignore-changes`. This throws away changes made inside the isolated checkout,
+which means no revision gets rewritten and immutable commits are fair game too.
+It is not a sandbox, though: side effects elsewhere, such as network requests
+or writes outside the checkout, still happen.
+
+```console
+$ jj run -r 'trunk()..@' --ignore-changes -- cargo test
+```
+
+When everything passes, `jj` says so and leaves the stack untouched:
+
+```console
+$ jj run -r 'description(glob:"step*")' --ignore-changes -- sh -c 'test $(cat n.txt) -gt 3'
+Nothing changed.
+```
+
+When something fails, `jj` stops and names the offending revision:
+
+```console
+Error: the command 'sh -c test $(cat n.txt) -gt 3' failed with exit status: 1
+Hint: Failed revision: nwwnpuuz 7f1e1a07 step one
+```
+
+This is useful because a pre-commit hook checks the tip, while
+`jj run --ignore-changes` checks every commit in the stack independently. We
+can catch a stack that passes at the top but is broken three commits down. It's
+the same idea as
+[`jj bisect`](../fixing-problems/bisecting.md), run exhaustively instead of by
+binary search.
+
+Each command runs with `JJ_CHANGE_ID`, `JJ_COMMIT_ID`, and `JJ_WORKSPACE_ROOT`
+in its environment, and `-j` runs several revisions in parallel:
+
+```console
+$ jj run -r 'trunk()..@' --ignore-changes -j 4 -- cargo test
+```
+
+## Rewriting a whole stack
+
+For the second job, let's leave off `--ignore-changes`. Now the filesystem
+changes stick, and each revision is amended with the command's output. This is
+how we can apply a codemod across history instead of applying it to the tip and
+patching up the earlier commits afterwards.
+
+```console
+$ jj run -r 'description(glob:"call foo*")' -- sh -c "find . -name '*.rs' -exec sed -i '' 's/foo/bar/g' {} +"
+Rewrote 2 commits.
+```
+
+Every commit that called `foo` now calls `bar`, as if you'd made the rename from
+the start. `jj fix` covers the formatting case with less ceremony; reach for
+`jj run` when the transformation is a real command, not a stdin-to-stdout
+filter.
+
+## Commands that are safe to repeat
+
+There's one important rule: our command has to be *idempotent* across the stack,
+because `jj` runs it once per revision and then rebases each result onto the
+last. A rename is fine; if we apply it twice, the second pass is a no-op. A
+blind `echo X >> file` is not. Every commit appends its own `X`, the rebased
+contents no longer agree, and we get conflicts instead of a clean rewrite. If
+the command's output depends on what came before, we should use a different
+approach.
+
+For anything read-only — tests, linters, a build check — pass `--ignore-changes`
+and the question doesn't arise.

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -21,11 +21,11 @@ Let's check out our example project to make sure we're on the same place:
 
 ```console
 > jj log
-@  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+@  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │  add a new function
-◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ```
 
@@ -44,13 +44,13 @@ Working copy  (@) now at: opwqpunl 7ede4eb9 (empty) (no description set)
 Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 ~/Documents/GitHub/sample-jj-project/hello-world> jj log
-@  opwqpunl steve@steveklabnik.com 2024-03-17 14:12:52.000 -05:00 7ede4eb9
+@  opwqpunl steve@steveklabnik.com 2024-03-17 14:12:52 7ede4eb9
 │  (empty) (no description set)
-│ ◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+│ ○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │  add a new function
-│ ◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+│ ○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 ├─╯  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -72,15 +72,15 @@ Creating branch push-yxxppztpoyqq for revision @
 Branch changes to push to origin:
   Add branch push-yxxppztpoyqq to 3d1231518dbf
 > jj log
-@  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+@  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │  (empty) have galactus query eks with time range
-◉  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+○  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 │  (empty) display the birthday date on the settings page
-│ ◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+│ ○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │  add a new function
-│ ◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+│ ○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 ├─╯  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -105,27 +105,27 @@ Your `jj log` will look like this:
 
 ```console
 > jj log
-@  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31.000 -05:00 push-ymvptyyqmyul 728dbb1e
+@  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31 push-ymvptyyqmyul 728dbb1e
 │  (empty) fixing all the breakage from updating dependencies
-◉  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14.000 -05:00 1f7c69a5
+○  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 │  (empty) updating dependencies
-│ ◉  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ ○  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │  (empty) first 80% done
-│ ◉  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ ○  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 ├─╯  (empty) another feature
-│ ◉  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ ○  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │  (empty) various fixes
-│ ◉  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ ○  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 ├─╯  (empty) prepare to deploy to the cloud
-│ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ ○  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │  (empty) have galactus query eks with time range
-│ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+│ ○  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 ├─╯  (empty) display the birthday date on the settings page
-│ ◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+│ ○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │  add a new function
-│ ◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+│ ○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 ├─╯  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ```
 
@@ -181,31 +181,31 @@ Check out this `jj log`:
 
 ```console
 > jj log
-@  nllzosqm steve@steveklabnik.com 2024-03-17 14:36:36.000 -05:00 85324040
+@  nllzosqm steve@steveklabnik.com 2024-03-17 14:36:36 85324040
 │  (empty) (no description set)
-◉          xnutwmso steve@steveklabnik.com 2024-03-17 14:30:52.000 -05:00 695806ff
+○          xnutwmso steve@steveklabnik.com 2024-03-17 14:30:52 695806ff
 ├─┬─┬─┬─╮  (empty) merge: steve's branch
-│ │ │ │ ◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+│ │ │ │ ○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │ │ │ │  add a new function
-│ │ │ │ ◉  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+│ │ │ │ ○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 │ │ │ │ │  add a comment to main
-│ │ │ ◉ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ │ │ ○ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ ◉ │  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+│ │ │ ○ │  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 │ │ │ ├─╯  (empty) display the birthday date on the settings page
-│ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │ │ │  (empty) various fixes
-│ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ ◉ │  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ ○ │  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │ │  (empty) first 80% done
-│ ◉ │  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ ○ │  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 │ ├─╯  (empty) another feature
-◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31.000 -05:00 push-ymvptyyqmyul 728dbb1e
+○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31 push-ymvptyyqmyul 728dbb1e
 │ │  (empty) fixing all the breakage from updating dependencies
-◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14.000 -05:00 1f7c69a5
+○ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 ├─╯  (empty) updating dependencies
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ```
 
@@ -222,31 +222,31 @@ Working copy  (@) now at: kvupxvpv 2ea49586 (empty) second 80% done
 Parent commit (@-)      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
 Added 0 files, modified 1 files, removed 0 files
 > jj log
-    @  kvupxvpv steve@steveklabnik.com 2024-03-17 14:43:28.000 -05:00 46cb6847
+    @  kvupxvpv steve@steveklabnik.com 2024-03-17 14:43:28 46cb6847
     | (empty) second 80% done
-  ◉ |      xnutwmso steve@steveklabnik.com 2024-03-17 14:30:52.000 -05:00 695806ff
+  ○ |      xnutwmso steve@steveklabnik.com 2024-03-17 14:30:52 695806ff
 ╭─┼─┬─┬─╮  (empty) merge: steve's branch
-◉ │ │ │ │  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk 752534be
+○ │ │ │ │  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
 │ │ │ │ │  add a new function
-◉ │ │ │ │  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+○ │ │ │ │  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 │ │ │ │ │  add a comment to main
-│ │ │ │ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ │ │ │ ○  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ │ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+│ │ │ │ ○  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 ├───────╯  (empty) display the birthday date on the settings page
-│ │ │ ◉  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ │ │ ○  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │ │ │  (empty) various fixes
-│ │ │ ◉  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ │ │ ○  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 ├─────╯  (empty) prepare to deploy to the cloud
-│ │ ◉  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ │ ○  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │ │  (empty) first 80% done
-│ │ ◉  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ │ ○  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 ├───╯  (empty) another feature
-│ ◉  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31.000 -05:00 push-ymvptyyqmyul 728dbb1e
+│ ○  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31 push-ymvptyyqmyul 728dbb1e
 │ │  (empty) fixing all the breakage from updating dependencies
-│ ◉  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14.000 -05:00 1f7c69a5
+│ ○  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 ├─╯  (empty) updating dependencies
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ```
 
@@ -262,19 +262,19 @@ happen:
 
 ```console
 > jj log
-◉          xnutwmso steve@steveklabnik.com 2024-03-17 15:16:36.000 -05:00 da67dfe1
+○          xnutwmso steve@steveklabnik.com 2024-03-17 15:16:36 da67dfe1
 ├─┬─┬─┬─╮  (empty) merge: steve's branch
-│ │ │ │ @  kvupxvpv steve@steveklabnik.com 2024-03-17 15:15:20.000 -05:00 2ea49586
+│ │ │ │ @  kvupxvpv steve@steveklabnik.com 2024-03-17 15:15:20 2ea49586
 │ │ │ │ │  (empty) second 80% done
-│ │ │ │ ◉  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ │ │ │ ○  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │ │ │ │  (empty) first 80% done
-│ │ │ │ ◉  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ │ │ │ ○  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 │ │ │ │ │  (empty) another feature
-│ │ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ │ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │ │ │ │  (empty) various fixes
-│ │ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ │ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 │ │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ │ ◉ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ │ ○ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │ │ │  (empty) have galactus query eks with time range
 <snip>
 ~
@@ -289,9 +289,9 @@ Working copy  (@) now at: pptrunzw 06442487 (empty) (no description set)
 Parent commit (@-)      : xnutwmso bcf8a74b (empty) merge: steve's branch
 Added 0 files, modified 2 files, removed 0 files
 > jj log
-@  pptrunzw steve@steveklabnik.com 2024-03-17 14:55:59.000 -05:00 06442487
+@  pptrunzw steve@steveklabnik.com 2024-03-17 14:55:59 06442487
 │  (empty) (no description set)
-◉          xnutwmso steve@steveklabnik.com 2024-03-17 14:52:08.000 -05:00 bcf8a74b
+○          xnutwmso steve@steveklabnik.com 2024-03-17 14:52:08 bcf8a74b
 ├─┬─┬─┬─╮  (empty) merge: steve's branch
 
 <snip>
@@ -316,35 +316,35 @@ After fetching changes, our log looks like this:
 ```console
 > jj git fetch
 > jj log
-@  xqkmpxlq steve@steveklabnik.com 2024-03-17 15:18:11.000 -05:00 fccf0626
+@  xqkmpxlq steve@steveklabnik.com 2024-03-17 15:18:11 fccf0626
 │  (empty) (no description set)
-◉          xnutwmso steve@steveklabnik.com 2024-03-17 15:16:36.000 -05:00 da67dfe1
+○          xnutwmso steve@steveklabnik.com 2024-03-17 15:16:36 da67dfe1
 ├─┬─┬─┬─╮  (empty) merge: steve's branch
-│ │ │ │ ◉  kvupxvpv steve@steveklabnik.com 2024-03-17 15:15:20.000 -05:00 2ea49586
+│ │ │ │ ○  kvupxvpv steve@steveklabnik.com 2024-03-17 15:15:20 2ea49586
 │ │ │ │ │  (empty) second 80% done
-│ │ │ │ ◉  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56.000 -05:00 push-zxyukunnwolo 30081a6b
+│ │ │ │ ○  zxyukunn steve@steveklabnik.com 2024-03-17 14:24:56 push-zxyukunnwolo 30081a6b
 │ │ │ │ │  (empty) first 80% done
-│ │ │ │ ◉  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21.000 -05:00 7c02f6ce
+│ │ │ │ ○  tzsloruo steve@steveklabnik.com 2024-03-17 14:24:21 7c02f6ce
 │ │ │ │ │  (empty) another feature
-│ │ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00.000 -05:00 push-rxpztwmsszvk 902a6cd2
+│ │ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 14:23:00 push-rxpztwmsszvk 902a6cd2
 │ │ │ │ │  (empty) various fixes
-│ │ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15.000 -05:00 105cf6b5
+│ │ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 14:22:15 105cf6b5
 │ │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ │ ◉ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00.000 -05:00 push-yxxppztpoyqq 3d123151
+│ │ ○ │  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │ │ │ │  (empty) have galactus query eks with time range
-│ │ ◉ │  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58.000 -05:00 1a66beb1
+│ │ ○ │  opwqpunl steve@steveklabnik.com 2024-03-17 14:15:58 1a66beb1
 │ │ ├─╯  (empty) display the birthday date on the settings page
-│ ◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31.000 -05:00 push-ymvptyyqmyul 728dbb1e
+│ ○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 14:25:31 push-ymvptyyqmyul 728dbb1e
 │ │ │  (empty) fixing all the breakage from updating dependencies
-│ ◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14.000 -05:00 1f7c69a5
+│ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 │ ├─╯  (empty) updating dependencies
-◉ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 14:45:41.000 -05:00 push-vmunwxsksqvk* cdca9211
+○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 14:45:41 push-vmunwxsksqvk* cdca9211
 │ │  add a new function
-◉ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 14:45:41.000 -05:00 3a08be8a
+○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 14:45:41 3a08be8a
 ├─╯  add a comment to main
-│ ◉  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02.000 -05:00 trunk b7f9d708
+│ ◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 trunk b7f9d708
 ╭─╯  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -449,35 +449,35 @@ Here's what our `jj log` looks like:
 
 ```console
 > jj log
-◉  xnutwmso steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 ce833ae7
+○  xnutwmso steve@steveklabnik.com 2024-03-17 16:01:56 ce833ae7
 │  (empty) merge: steve's branch
-◉          xqkmpxlq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 5dc292c2
+○          xqkmpxlq steve@steveklabnik.com 2024-03-17 16:01:56 5dc292c2
 ├─┬─┬─┬─╮  (empty) (no description set)
-│ │ │ │ │ @  ltupzukw steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 edf9cd58
+│ │ │ │ │ @  ltupzukw steve@steveklabnik.com 2024-03-17 16:01:56 edf9cd58
 ╭─┬─┬─┬─┬─╯  (empty) (no description set)
-│ │ │ │ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-yxxppztpoyqq* b3db74d3
+│ │ │ │ ○  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56 push-yxxppztpoyqq* b3db74d3
 │ │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ │ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 713c692d
+│ │ │ │ ○  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56 713c692d
 │ │ │ │ │  (empty) display the birthday date on the settings page
-│ │ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-rxpztwmsszvk* 76dbbcd1
+│ │ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56 push-rxpztwmsszvk* 76dbbcd1
 │ │ │ │ │  (empty) various fixes
-│ │ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d0f7f627
+│ │ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56 d0f7f627
 │ │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ │ ◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-ymvptyyqmyul* f448e93a
+│ │ ○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56 push-ymvptyyqmyul* f448e93a
 │ │ │ │  (empty) fixing all the breakage from updating dependencies
-│ │ ◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d608ebd3
+│ │ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56 d608ebd3
 │ │ ├─╯  (empty) updating dependencies
-│ ◉ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-vmunwxsksqvk* 21569f7a
+│ ○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56 push-vmunwxsksqvk* 21569f7a
 │ │ │  (empty) add a new function
-│ ◉ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 9a050939
+│ ○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56 9a050939
 │ ├─╯  (empty) add a comment to main
-◉ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 3b0a722a
+○ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56 3b0a722a
 │ │  (empty) second 80% done
-◉ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-zxyukunnwolo* 7e826ad4
+○ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56 push-zxyukunnwolo* 7e826ad4
 │ │  (empty) first 80% done
-◉ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 792cc601
+○ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56 792cc601
 ├─╯  (empty) another feature
-◉  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02.000 -05:00 trunk b7f9d708
+◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 trunk b7f9d708
 │  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
 ~
 ```
@@ -491,35 +491,35 @@ Parent commit (@-)      : xnutwmso ce833ae7 (empty) merge: steve's branch
 > jj abandon l
 Abandoned commit ltupzukw edf9cd58 (empty) (no description set)
 > jj log
-@  vvvouunp steve@steveklabnik.com 2024-03-17 16:02:39.000 -05:00 78919d69
+@  vvvouunp steve@steveklabnik.com 2024-03-17 16:02:39 78919d69
 │  (empty) (no description set)
-◉  xnutwmso steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 ce833ae7
+○  xnutwmso steve@steveklabnik.com 2024-03-17 16:01:56 ce833ae7
 │  (empty) merge: steve's branch
-◉          xqkmpxlq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 5dc292c2
+○          xqkmpxlq steve@steveklabnik.com 2024-03-17 16:01:56 5dc292c2
 ├─┬─┬─┬─╮  (empty) (no description set)
-│ │ │ │ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-yxxppztpoyqq* b3db74d3
+│ │ │ │ ○  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56 push-yxxppztpoyqq* b3db74d3
 │ │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ │ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 713c692d
+│ │ │ │ ○  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56 713c692d
 │ │ │ │ │  (empty) display the birthday date on the settings page
-│ │ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-rxpztwmsszvk* 76dbbcd1
+│ │ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56 push-rxpztwmsszvk* 76dbbcd1
 │ │ │ │ │  (empty) various fixes
-│ │ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d0f7f627
+│ │ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56 d0f7f627
 │ │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ │ ◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-ymvptyyqmyul* f448e93a
+│ │ ○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56 push-ymvptyyqmyul* f448e93a
 │ │ │ │  (empty) fixing all the breakage from updating dependencies
-│ │ ◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d608ebd3
+│ │ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56 d608ebd3
 │ │ ├─╯  (empty) updating dependencies
-│ ◉ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-vmunwxsksqvk* 21569f7a
+│ ○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56 push-vmunwxsksqvk* 21569f7a
 │ │ │  (empty) add a new function
-│ ◉ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 9a050939
+│ ○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56 9a050939
 │ ├─╯  (empty) add a comment to main
-◉ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 3b0a722a
+○ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56 3b0a722a
 │ │  (empty) second 80% done
-◉ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-zxyukunnwolo* 7e826ad4
+○ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56 push-zxyukunnwolo* 7e826ad4
 │ │  (empty) first 80% done
-◉ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 792cc601
+○ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56 792cc601
 ├─╯  (empty) another feature
-◉  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02.000 -05:00 trunk b7f9d708
+◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 trunk b7f9d708
 │  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
 ~
 ```
@@ -545,31 +545,31 @@ And now our log is clean:
 
 ```text
 > jj log
-@  vvvouunp steve@steveklabnik.com 2024-03-17 16:06:15.000 -05:00 e3f9254f
+@  vvvouunp steve@steveklabnik.com 2024-03-17 16:06:15 e3f9254f
 │  (empty) (no description set)
-◉  xnutwmso steve@steveklabnik.com 2024-03-17 16:06:15.000 -05:00 0459bd1c
+○  xnutwmso steve@steveklabnik.com 2024-03-17 16:06:15 0459bd1c
 │  (empty) merge: steve's branch
-◉        xqkmpxlq steve@steveklabnik.com 2024-03-17 16:06:15.000 -05:00 c9e5fa35
+○        xqkmpxlq steve@steveklabnik.com 2024-03-17 16:06:15 c9e5fa35
 ├─┬─┬─╮  (empty) (no description set)
-│ │ │ ◉  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-yxxppztpoyqq* b3db74d3
+│ │ │ ○  yxxppztp steve@steveklabnik.com 2024-03-17 16:01:56 push-yxxppztpoyqq* b3db74d3
 │ │ │ │  (empty) have galactus query eks with time range
-│ │ │ ◉  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 713c692d
+│ │ │ ○  opwqpunl steve@steveklabnik.com 2024-03-17 16:01:56 713c692d
 │ │ │ │  (empty) display the birthday date on the settings page
-│ │ ◉ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-rxpztwmsszvk* 76dbbcd1
+│ │ ○ │  rxpztwms steve@steveklabnik.com 2024-03-17 16:01:56 push-rxpztwmsszvk* 76dbbcd1
 │ │ │ │  (empty) various fixes
-│ │ ◉ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d0f7f627
+│ │ ○ │  tmnmvxyy steve@steveklabnik.com 2024-03-17 16:01:56 d0f7f627
 │ │ ├─╯  (empty) prepare to deploy to the cloud
-│ ◉ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-ymvptyyqmyul* f448e93a
+│ ○ │  ymvptyyq steve@steveklabnik.com 2024-03-17 16:01:56 push-ymvptyyqmyul* f448e93a
 │ │ │  (empty) fixing all the breakage from updating dependencies
-│ ◉ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 d608ebd3
+│ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56 d608ebd3
 │ ├─╯  (empty) updating dependencies
-◉ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 3b0a722a
+○ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56 3b0a722a
 │ │  (empty) second 80% done
-◉ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 push-zxyukunnwolo* 7e826ad4
+○ │  zxyukunn steve@steveklabnik.com 2024-03-17 16:01:56 push-zxyukunnwolo* 7e826ad4
 │ │  (empty) first 80% done
-◉ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56.000 -05:00 792cc601
+○ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56 792cc601
 ├─╯  (empty) another feature
-◉  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02.000 -05:00 push-vmunwxsksqvk* trunk b7f9d708
+◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 push-vmunwxsksqvk* trunk b7f9d708
 │  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
 ~
 ```

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -360,7 +360,7 @@ above that that is true.
 We can rebase all of our PRs with one command:
 
 ```console
-> jj rebase -s 'all:roots(trunk..@)' -o trunk
+> jj rebase -s 'roots(trunk..@)' -o trunk
 Rebased 14 commits to destination.
 Working copy  (@) now at: ltupzukw 9a496ef6 (empty) (no description set)
 Parent commit (@-)      : xnutwmso 6be25a32 (empty) merge: steve's branch
@@ -372,8 +372,8 @@ This is using `jj rebase -s` rather than `-r`, like we've been doing before. Her
 the description from `jj rebase --help`:
 
 ```text
-  -s, --source <SOURCE>
-          Rebase specified revision(s) together their tree of descendants (can be repeated)
+  -s, --source <REVSETS>
+          Rebase specified revision(s) together with their trees of descendants (can be repeated)
 ```
 
 That's a little rough. There are some helpful diagrams in `jj rebase --help` that
@@ -402,29 +402,10 @@ A - B
 
 as both `C` and `D` are somewhere else now. `-b` works to rebase a branch.
 
-The next part, `all:` is a prefix. What's the prefix do? Well, let's try running
-the command without it:
-
-```console
-> jj rebase -s 'roots(trunk..@)' -o trunk
-Error: Revset "roots(trunk..@)" resolved to more than one revision
-Hint: The revset "roots(trunk..@)" resolved to these revisions:
-opwqpunl ba100a96 (empty) display the birthday date on the settings page
-tmnmvxyy 462dcf72 (empty) prepare to deploy to the cloud
-tzsloruo fdba6abd (empty) another feature
-xulymzyp abbf424e (empty) updating dependencies
-vmunwxsk?? 2ce46bd0 (empty) add a comment to main
-Prefix the expression with 'all' to allow any number of revisions (i.e. 'all:roots(trunk..@)').
-```
-
-This is basically a way to help make sure you've got the right arguments: sometimes
-when working with revsets, you expect the result to be only one revision, and
-sometimes you expect it to be many revisions. For some commands, one or the
-other may be not necessarily what you want. In this case, most of the time,
-when you rebase, you only want one parent. So if we use a revset that returns
-more than one change, that might be a bug! So `jj rebase` wants us to reassure
-it that we are creating a change with multiple parents by putting `all:` as a
-prefix.
+Note that `-s` takes a revset that may resolve to many revisions, and every one
+of them gets rebased. Older versions of `jj` made you write an `all:` prefix
+(`'all:roots(trunk..@)'`) to confirm you meant more than one revision. That
+prefix has been removed; passing it now is a parse error.
 
 Finally, `trunk..@` is being passed to the `roots()` function. `trunk..@` is
 a range, so it will give every change between where `trunk` is and `@`. The
@@ -439,7 +420,7 @@ themselves. The roots of the tree.
 Let's put it all together:
 
 ```console
-$ jj rebase -s 'all:roots(trunk..@)' -o trunk
+$ jj rebase -s 'roots(trunk..@)' -o trunk
 ```
 
 > We're rebasing all of the root changes from `trunk` to `@` onto `trunk`.

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -337,9 +337,9 @@ After fetching changes, our log looks like this:
 │ │ │  (empty) fixing all the breakage from updating dependencies
 │ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 14:25:14 1f7c69a5
 │ ├─╯  (empty) updating dependencies
-○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 14:45:41 push-vmunwxsksqvk* cdca9211
+○ │  msmntwvo/1 steve@steveklabnik.com 2024-03-17 14:45:41 push-vmunwxsksqvk* cdca9211 (divergent)
 │ │  add a new function
-○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 14:45:41 3a08be8a
+○ │  vmunwxsk/1 steve@steveklabnik.com 2024-03-17 14:45:41 3a08be8a (divergent)
 ├─╯  add a comment to main
 │ ◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 trunk b7f9d708
 ╭─╯  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
@@ -348,11 +348,17 @@ After fetching changes, our log looks like this:
 ~
 ```
 
-Uh oh! That's got some concerning stuff. The changes with `??` and are in red,
-and there's also the new merge commit that `trunk` is set up to. Since all of
-our branches were off of the change where `trunk` used to be, we should rebase
-them on top of the new trunk.  First, we want to make sure that `@` is at the
-empty change on top of our merge commit. You can see from the `jj log` just
+Uh oh! That's got some concerning stuff. Two of our changes are now marked
+`(divergent)`, with those `/1` suffixes on their change IDs. That's because the
+merge that just landed on `trunk` contains the *pushed* version of our PR's
+commits, while our local copies have been rewritten since — so each of those
+change IDs now names two visible commits. We'll deal with them in a moment,
+and there's a whole chapter on
+[divergent changes](../fixing-problems/divergent-changes.md) if you want the
+full story. There's also the new merge commit that `trunk` is set up to. Since
+all of our branches were off of the change where `trunk` used to be, we should
+rebase them on top of the new trunk. First, we want to make sure that `@` is at
+the empty change on top of our merge commit. You can see from the `jj log` just
 above that that is true.
 
 We can rebase all of our PRs with one command:
@@ -447,9 +453,9 @@ Here's what our `jj log` looks like:
 │ │ │ │  (empty) fixing all the breakage from updating dependencies
 │ │ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56 d608ebd3
 │ │ ├─╯  (empty) updating dependencies
-│ ○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56 push-vmunwxsksqvk* 21569f7a
+│ ○ │  msmntwvo/1 steve@steveklabnik.com 2024-03-17 16:01:56 push-vmunwxsksqvk* 21569f7a (divergent)
 │ │ │  (empty) add a new function
-│ ○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56 9a050939
+│ ○ │  vmunwxsk/1 steve@steveklabnik.com 2024-03-17 16:01:56 9a050939 (divergent)
 │ ├─╯  (empty) add a comment to main
 ○ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56 3b0a722a
 │ │  (empty) second 80% done
@@ -490,9 +496,9 @@ Abandoned 1 commits:
 │ │ │ │  (empty) fixing all the breakage from updating dependencies
 │ │ ○ │  xulymzyp steve@steveklabnik.com 2024-03-17 16:01:56 d608ebd3
 │ │ ├─╯  (empty) updating dependencies
-│ ○ │  msmntwvo?? steve@steveklabnik.com 2024-03-17 16:01:56 push-vmunwxsksqvk* 21569f7a
+│ ○ │  msmntwvo/1 steve@steveklabnik.com 2024-03-17 16:01:56 push-vmunwxsksqvk* 21569f7a (divergent)
 │ │ │  (empty) add a new function
-│ ○ │  vmunwxsk?? steve@steveklabnik.com 2024-03-17 16:01:56 9a050939
+│ ○ │  vmunwxsk/1 steve@steveklabnik.com 2024-03-17 16:01:56 9a050939 (divergent)
 │ ├─╯  (empty) add a comment to main
 ○ │  kvupxvpv steve@steveklabnik.com 2024-03-17 16:01:56 3b0a722a
 │ │  (empty) second 80% done
@@ -505,24 +511,27 @@ Abandoned 1 commits:
 ~
 ```
 
-Looking pretty good! One last thing: what's up with those red commits? Well,
-those are from our external PR, and we don't need them. So we can just abandon
-that branch:
+Looking pretty good! One last thing: what's up with those divergent commits?
+Those are our local copies of the two changes that already landed on `trunk`
+through the merged PR. The versions inside `trunk` are the ones that matter
+now, so we can abandon the whole local line. We use commit IDs rather than the
+change IDs — the change IDs are exactly what's ambiguous when a change is
+divergent:
 
 ```console
-> jj abandon push-vmunwxsksqvk
-Abandoned 1 commits:
-  msmntwvo?? 21569f7a push-vmunwxsksqvk* | (empty) add a new function
-Rebased 3 descendant commits onto parents of abandoned commits
-Working copy  (@) now at: vvvouunp ace3f1a2 (empty) (no description set)
-Parent commit (@-)      : xnutwmso 32871810 (empty) merge: steve's branch
-> jj abandon push-vmunwxsksqvk
-Abandoned 1 commits:
-  vmunwxsk?? 9a050939 push-vmunwxsksqvk* | (empty) add a comment to main
+> jj abandon '9a050939::21569f7a'
+Abandoned 2 commits:
+  msmntwvo/1 21569f7a push-vmunwxsksqvk* | (divergent) (empty) add a new function
+  vmunwxsk/1 9a050939 (divergent) (empty) add a comment to main
+Deleted bookmarks: push-vmunwxsksqvk
 Rebased 3 descendant commits onto parents of abandoned commits
 Working copy  (@) now at: vvvouunp e3f9254f (empty) (no description set)
 Parent commit (@-)      : xnutwmso 0459bd1c (empty) merge: steve's branch
 ```
+
+Notice that `jj` deleted the `push-vmunwxsksqvk` bookmark for us as part of
+the abandon, which suits us fine: the pull request is merged, and
+`jj git push --deleted` will clean the branch up on GitHub too.
 
 And now our log is clean:
 
@@ -552,7 +561,7 @@ And now our log is clean:
 │ │  (empty) first 80% done
 ○ │  tzsloruo steve@steveklabnik.com 2024-03-17 16:01:56 792cc601
 ├─╯  (empty) another feature
-◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 push-vmunwxsksqvk* trunk b7f9d708
+◆  okyzuxnk steve@steveklabnik.com 2024-03-17 14:59:02 trunk b7f9d708
 │  (empty) Merge pull request #1 from steveklabnik/push-vmunwxsksqvk
 ~
 ```

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -254,6 +254,7 @@ Yikes! Don't worry, we can fix that with a rebase:
 
 ```console
 > jj rebase -r xn -o m -o ym -o yx -o r -o kv
+Rebased 1 commits to destination.
 ```
 
 We want to rebase the revision `xn` "onto" the following destination revisions:
@@ -360,7 +361,7 @@ We can rebase all of our PRs with one command:
 
 ```console
 > jj rebase -s 'all:roots(trunk..@)' -o trunk
-Rebased 14 commits
+Rebased 14 commits to destination.
 Working copy  (@) now at: ltupzukw 9a496ef6 (empty) (no description set)
 Parent commit (@-)      : xnutwmso 6be25a32 (empty) merge: steve's branch
 ```
@@ -489,7 +490,8 @@ Let's move `@` back to where we want it:
 Working copy  (@) now at: vvvouunp 78919d69 (empty) (no description set)
 Parent commit (@-)      : xnutwmso ce833ae7 (empty) merge: steve's branch
 > jj abandon l
-Abandoned commit ltupzukw edf9cd58 (empty) (no description set)
+Abandoned 1 commits:
+  ltupzukw edf9cd58 (empty) (no description set)
 > jj log
 @  vvvouunp steve@steveklabnik.com 2024-03-17 16:02:39 78919d69
 │  (empty) (no description set)
@@ -530,12 +532,14 @@ that branch:
 
 ```console
 > jj abandon push-vmunwxsksqvk
-Abandoned commit msmntwvo?? 21569f7a push-vmunwxsksqvk* | (empty) add a new function
+Abandoned 1 commits:
+  msmntwvo?? 21569f7a push-vmunwxsksqvk* | (empty) add a new function
 Rebased 3 descendant commits onto parents of abandoned commits
 Working copy  (@) now at: vvvouunp ace3f1a2 (empty) (no description set)
 Parent commit (@-)      : xnutwmso 32871810 (empty) merge: steve's branch
 > jj abandon push-vmunwxsksqvk
-Abandoned commit vmunwxsk?? 9a050939 push-vmunwxsksqvk* | (empty) add a comment to main
+Abandoned 1 commits:
+  vmunwxsk?? 9a050939 push-vmunwxsksqvk* | (empty) add a comment to main
 Rebased 3 descendant commits onto parents of abandoned commits
 Working copy  (@) now at: vvvouunp e3f9254f (empty) (no description set)
 Parent commit (@-)      : xnutwmso 0459bd1c (empty) merge: steve's branch

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -40,8 +40,8 @@ other:
 
 ```console
 > jj new trunk
-Working copy now at: opwqpunl 7ede4eb9 (empty) (no description set)
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: opwqpunl 7ede4eb9 (empty) (no description set)
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 ~/Documents/GitHub/sample-jj-project/hello-world> jj log
 @  opwqpunl steve@steveklabnik.com 2024-03-17 14:12:52.000 -05:00 7ede4eb9
@@ -62,11 +62,11 @@ matter for our purposes.
 
 ```console
 > jj describe -m "display the birthday date on the settings page"
-Working copy now at: opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 > jj new -m "have galactus query eks with time range"
-Working copy now at: yxxppztp 3d123151 (empty) have galactus query eks with time range
-Parent commit      : opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
+Working copy  (@) now at: yxxppztp 3d123151 (empty) have galactus query eks with time range
+Parent commit (@-)      : opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
 > jj git push -c @
 Creating branch push-yxxppztpoyqq for revision @
 Branch changes to push to origin:
@@ -90,11 +90,11 @@ three times. It's cooler with more branches, trust me.
 
 ```console
 > jj new trunk -m "prepare to deploy to the cloud"
-Working copy now at: tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 > jj new -m "various fixes"
-Working copy now at: rxpztwms 902a6cd2 (empty) various fixes
-Parent commit      : tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
+Working copy  (@) now at: rxpztwms 902a6cd2 (empty) various fixes
+Parent commit (@-)      : tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
 > jj git push -c @
 Creating branch push-rxpztwmsszvk for revision @
 Branch changes to push to origin:
@@ -145,12 +145,12 @@ of them! Anyway:
 
 ```console
 > jj new ym z r yx m -m "merge: steve's branch"
-Working copy now at: xnutwmso 695806ff (empty) merge: steve's branch
-Parent commit      : ymvptyyq 728dbb1e push-ymvptyyqmyul | (empty) fixing all the breakage from updating dependencies
-Parent commit      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
-Parent commit      : rxpztwms 902a6cd2 push-rxpztwmsszvk | (empty) various fixes
-Parent commit      : yxxppztp 3d123151 push-yxxppztpoyqq | (empty) have galactus query eks with time range
-Parent commit      : msmntwvo 752534be push-vmunwxsksqvk | add a new function
+Working copy  (@) now at: xnutwmso 695806ff (empty) merge: steve's branch
+Parent commit (@-)      : ymvptyyq 728dbb1e push-ymvptyyqmyul | (empty) fixing all the breakage from updating dependencies
+Parent commit (@-)      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
+Parent commit (@-)      : rxpztwms 902a6cd2 push-rxpztwmsszvk | (empty) various fixes
+Parent commit (@-)      : yxxppztp 3d123151 push-yxxppztpoyqq | (empty) have galactus query eks with time range
+Parent commit (@-)      : msmntwvo 752534be push-vmunwxsksqvk | add a new function
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -173,8 +173,8 @@ squash-style workflow more easily: we temporarily work on a `@` change, and then
 
 ```console
 > jj new
-Working copy now at: nllzosqm 85324040 (empty) (no description set)
-Parent commit      : xnutwmso 695806ff (empty) merge: steve's branch
+Working copy  (@) now at: nllzosqm 85324040 (empty) (no description set)
+Parent commit (@-)      : xnutwmso 695806ff (empty) merge: steve's branch
 ```
 
 Check out this `jj log`:
@@ -218,8 +218,8 @@ it's not too bad:
 
 ```console
 > jj new z -m "second 80% done"
-Working copy now at: kvupxvpv 2ea49586 (empty) second 80% done
-Parent commit      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
+Working copy  (@) now at: kvupxvpv 2ea49586 (empty) second 80% done
+Parent commit (@-)      : zxyukunn 30081a6b push-zxyukunnwolo | (empty) first 80% done
 Added 0 files, modified 1 files, removed 0 files
 > jj log
     @  kvupxvpv steve@steveklabnik.com 2024-03-17 14:43:28.000 -05:00 46cb6847
@@ -285,8 +285,8 @@ shuffle. It was empty anyway! Let's bring it back:
 
 ```console
 > jj new xn
-Working copy now at: pptrunzw 06442487 (empty) (no description set)
-Parent commit      : xnutwmso bcf8a74b (empty) merge: steve's branch
+Working copy  (@) now at: pptrunzw 06442487 (empty) (no description set)
+Parent commit (@-)      : xnutwmso bcf8a74b (empty) merge: steve's branch
 Added 0 files, modified 2 files, removed 0 files
 > jj log
 @  pptrunzw steve@steveklabnik.com 2024-03-17 14:55:59.000 -05:00 06442487
@@ -361,8 +361,8 @@ We can rebase all of our PRs with one command:
 ```console
 > jj rebase -s 'all:roots(trunk..@)' -o trunk
 Rebased 14 commits
-Working copy now at: ltupzukw 9a496ef6 (empty) (no description set)
-Parent commit      : xnutwmso 6be25a32 (empty) merge: steve's branch
+Working copy  (@) now at: ltupzukw 9a496ef6 (empty) (no description set)
+Parent commit (@-)      : xnutwmso 6be25a32 (empty) merge: steve's branch
 ```
 
 This is using some revset stuff we haven't seen before! Let's break it down:
@@ -486,8 +486,8 @@ Let's move `@` back to where we want it:
 
 ```console
 > jj new xn
-Working copy now at: vvvouunp 78919d69 (empty) (no description set)
-Parent commit      : xnutwmso ce833ae7 (empty) merge: steve's branch
+Working copy  (@) now at: vvvouunp 78919d69 (empty) (no description set)
+Parent commit (@-)      : xnutwmso ce833ae7 (empty) merge: steve's branch
 > jj abandon l
 Abandoned commit ltupzukw edf9cd58 (empty) (no description set)
 > jj log
@@ -532,13 +532,13 @@ that branch:
 > jj abandon push-vmunwxsksqvk
 Abandoned commit msmntwvo?? 21569f7a push-vmunwxsksqvk* | (empty) add a new function
 Rebased 3 descendant commits onto parents of abandoned commits
-Working copy now at: vvvouunp ace3f1a2 (empty) (no description set)
-Parent commit      : xnutwmso 32871810 (empty) merge: steve's branch
+Working copy  (@) now at: vvvouunp ace3f1a2 (empty) (no description set)
+Parent commit (@-)      : xnutwmso 32871810 (empty) merge: steve's branch
 > jj abandon push-vmunwxsksqvk
 Abandoned commit vmunwxsk?? 9a050939 push-vmunwxsksqvk* | (empty) add a comment to main
 Rebased 3 descendant commits onto parents of abandoned commits
-Working copy now at: vvvouunp e3f9254f (empty) (no description set)
-Parent commit      : xnutwmso 0459bd1c (empty) merge: steve's branch
+Working copy  (@) now at: vvvouunp e3f9254f (empty) (no description set)
+Parent commit (@-)      : xnutwmso 0459bd1c (empty) merge: steve's branch
 ```
 
 And now our log is clean:

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -68,9 +68,9 @@ Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Working copy  (@) now at: yxxppztp 3d123151 (empty) have galactus query eks with time range
 Parent commit (@-)      : opwqpunl 1a66beb1 (empty) display the birthday date on the settings page
 > jj git push -c @
-Creating branch push-yxxppztpoyqq for revision @
-Branch changes to push to origin:
-  Add branch push-yxxppztpoyqq to 3d1231518dbf
+Creating bookmark push-yxxppztpoyqq for revision yxxppztpoyqq
+Changes to push to origin:
+  bookmark: push-yxxppztpoyqq [add to 3d1231518dbf]
 > jj log
 @  yxxppztp steve@steveklabnik.com 2024-03-17 14:18:00 push-yxxppztpoyqq 3d123151
 │  (empty) have galactus query eks with time range
@@ -96,9 +96,9 @@ Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Working copy  (@) now at: rxpztwms 902a6cd2 (empty) various fixes
 Parent commit (@-)      : tmnmvxyy 105cf6b5 (empty) prepare to deploy to the cloud
 > jj git push -c @
-Creating branch push-rxpztwmsszvk for revision @
-Branch changes to push to origin:
-  Add branch push-rxpztwmsszvk to 902a6cd22f30
+Creating bookmark push-rxpztwmsszvk for revision rxpztwmsszvk
+Changes to push to origin:
+  bookmark: push-rxpztwmsszvk [add to 902a6cd22f30]
 ```
 
 Your `jj log` will look like this:
@@ -165,7 +165,7 @@ squash-style workflow more easily: we temporarily work on a `@` change, and then
 > ```sh
 > jj absorb         # absorb from @ into appropriate mutable parents
 > jj absorb src/    # limit to a file tree
-> jj absorb -f @ -t mutable()  # explicit source/target
+> jj absorb -f @ --into 'mutable()'  # explicit source/target
 > jj op show -p     # inspect the planned moves
 > ```
 >

--- a/src/advanced/simultaneous-edits.md
+++ b/src/advanced/simultaneous-edits.md
@@ -158,18 +158,16 @@ Whew! What a change! Five parents. Let's create an extra one so we can use our
 squash-style workflow more easily: we temporarily work on a `@` change, and then
 `jj squash` diffs back into whichever parent makes the most sense.
 
-> **Tip: `jj absorb` — redistribute edits back into the right branches.**
-> When your working copy (`@`) contains edits that belong to multiple PRs, `jj absorb` will push those edits into the nearest mutable ancestors instead of you manually splitting and rebase-ing.
-> Example:
->
-> ```sh
-> jj absorb         # absorb from @ into appropriate mutable parents
-> jj absorb src/    # limit to a file tree
-> jj absorb -f @ --into 'mutable()'  # explicit source/target
-> jj op show -p     # inspect the planned moves
-> ```
->
-> Use it after developing across several branches in one working copy — it saves the cut-and-paste + rebase chore by automatically redistributing changes where they belong.
+This is also where `jj absorb` earns its keep. With five parents in reach, a
+working copy full of small fixes belongs in five different places, and absorb
+files each hunk into whichever of them last touched those lines:
+
+```console
+$ jj absorb
+```
+
+We covered it back in the real-world workflows section. Everything it can't
+place with certainty stays in `@` for you to deal with.
 
 ```console
 > jj new

--- a/src/advanced/stacked-prs.md
+++ b/src/advanced/stacked-prs.md
@@ -1,0 +1,200 @@
+# Stacked pull requests
+
+Back in the conflicts chapter, I said that recording conflicts and rebasing
+automatically were the ingredients for a useful workflow. It's time to see what
+I meant.
+
+Let's say we're building something that's too big for one pull request. We
+could open one very large pull request, or open a small one and wait for it to
+merge before starting the next piece. Neither option lets us keep moving while
+still giving the reviewer small changes.
+
+The third option is a *stack*: a chain of small pull requests, each based on the
+one below, reviewed and merged from the bottom up. This is possible in `git`,
+but maintaining the stack takes work. Every time the bottom changes during
+review, every branch above it needs to be rebased.
+
+`jj` has been doing those rebases automatically since chapter one. That makes
+the workflow much easier to maintain.
+
+## Building the stack
+
+Let's build a feature in three pieces, each on top of the last:
+
+```console
+$ jj new trunk -m "add the parser"
+$ jj new -m "add the evaluator"
+$ jj new -m "wire it up to the CLI"
+$ jj log
+@  nvpxkvxo steve@steveklabnik.com 2024-03-21 09:45:24 6850afd9
+│  wire it up to the CLI
+○  mwzzqwkt steve@steveklabnik.com 2024-03-21 09:45:24 716bd51d
+│  add the evaluator
+○  rtotzlru steve@steveklabnik.com 2024-03-21 09:45:24 904decf4
+│  add the parser
+◆  mnysvqxx steve@steveklabnik.com 2024-03-21 09:45:23 trunk eecde2ae
+│  Update Cargo.toml
+```
+
+Nothing new so far — that's just three changes in a row. GitHub needs names,
+though, so let's give each one a bookmark:
+
+```console
+$ jj bookmark create parser -r rtotzlru
+Created 1 bookmarks pointing to rtotzlru 904decf4 parser | add the parser
+$ jj bookmark create evaluator -r mwzzqwkt
+Created 1 bookmarks pointing to mwzzqwkt 716bd51d evaluator | add the evaluator
+$ jj bookmark create cli -r nvpxkvxo
+Created 1 bookmarks pointing to nvpxkvxo 6850afd9 cli | wire it up to the CLI
+```
+
+`jj git push` takes `-b` more than once:
+
+```console
+$ jj git push -b parser -b evaluator -b cli
+Changes to push to origin:
+  bookmark: cli [add to 6850afd9040b]
+  bookmark: evaluator [add to 716bd51df2e4]
+  bookmark: parser [add to 904decf432ba]
+```
+
+Now open three PRs, each targeting the one below: `parser` into `trunk`,
+`evaluator` into `parser`, `cli` into `evaluator`. GitHub will show each PR
+containing only its own commit, which is the point — your reviewer sees three
+small diffs instead of one big one.
+
+## Updating the stack
+
+Now let's say someone reviews the bottom pull request and asks for a change. In
+`git`, we'd fix the parser commit, rebase `evaluator` onto it, and then rebase
+`cli` onto that. In `jj`, we can edit the commit directly:
+
+```console
+$ jj edit parser
+Working copy  (@) now at: rtotzlru 904decf4 parser | add the parser
+Parent commit (@-)      : mnysvqxx eecde2ae trunk | Update Cargo.toml
+```
+
+Make the fix the reviewer asked for, and look at the log:
+
+```console
+$ jj log
+Rebased 2 descendant commits onto updated working copy.
+○  nvpxkvxo steve@steveklabnik.com 2024-03-21 09:45:41 cli* c3b1a9f6
+│  wire it up to the CLI
+○  mwzzqwkt steve@steveklabnik.com 2024-03-21 09:45:41 evaluator* 5a6f2c6a
+│  add the evaluator
+@  rtotzlru steve@steveklabnik.com 2024-03-21 09:45:41 parser* 3b550959
+│  add the parser
+◆  mnysvqxx steve@steveklabnik.com 2024-03-21 09:45:23 trunk eecde2ae
+│  Update Cargo.toml
+```
+
+There's a lot in this one screen. `jj` rebased both descendants automatically,
+so every commit ID changed. The important bit is that *all three bookmarks are
+still attached to their commits*.
+They each grew an asterisk, meaning they've drifted from what the remote has,
+but none of them got left behind.
+
+That's the payoff for bookmarks following rewrites, which we covered a couple of
+chapters ago. Rewriting a commit carries its bookmark along, and an automatic
+rebase is a rewrite. So the entire stack re-pointed itself.
+
+One push updates all three pull requests:
+
+```console
+$ jj git push --all
+Changes to push to origin:
+  bookmark: cli [move sideways from 6850afd9040b to c3b1a9f61375]
+  bookmark: evaluator [move sideways from 716bd51df2e4 to 5a6f2c6aa13c]
+  bookmark: parser [move sideways from 904decf432ba to 3b550959d7d9]
+```
+
+That's the maintenance work we would otherwise have done by hand.
+
+## When the bottom merges
+
+Eventually the `parser` PR gets approved and merged. Fetch, and `trunk` has
+moved out from under your stack:
+
+```console
+$ jj git fetch
+bookmark: trunk@origin [updated] tracked
+$ jj log
+@  nvpxkvxo steve@steveklabnik.com 2024-03-21 09:45:41 cli c3b1a9f6
+│  wire it up to the CLI
+○  mwzzqwkt steve@steveklabnik.com 2024-03-21 09:45:41 evaluator 5a6f2c6a
+│  add the evaluator
+│ ◆  yzkopsqy maintainer@example.com 2024-03-21 09:46:07 trunk c5dd335b
+╭─┤  (empty) Merge pull request #1 from steve/parser
+│ │
+│ ~
+│
+◆  rtotzlru steve@steveklabnik.com 2024-03-21 09:45:41 parser 3b550959
+│  add the parser
+~
+```
+
+Two things changed shape here, and both are worth a look.
+
+`trunk` is a `◆` now, which we'd expect — it's the trunk, it's shared, it's
+immutable. But so is `parser`. Your parser commit got merged into `trunk`, which
+makes it an ancestor of `trunk`, which makes it immutable too. That work is
+shared now, so `jj` has stopped letting us rewrite it.
+
+The other thing: `evaluator` and `cli` are still sitting on the old `parser`
+commit, off to the side, while `trunk` has moved on. Move them across:
+
+```console
+$ jj rebase -s evaluator -o trunk
+Rebased 2 commits to destination.
+Working copy  (@) now at: nvpxkvxo a0bc5b05 cli* | wire it up to the CLI
+Parent commit (@-)      : mwzzqwkt 263f373c evaluator* | add the evaluator
+```
+
+`-s` takes the change and all its descendants, so `evaluator` and `cli` moved
+together, and their bookmarks came along as before:
+
+```console
+$ jj log
+@  nvpxkvxo steve@steveklabnik.com 2024-03-21 09:47:27 cli* a0bc5b05
+│  wire it up to the CLI
+○  mwzzqwkt steve@steveklabnik.com 2024-03-21 09:47:27 evaluator* 263f373c
+│  add the evaluator
+◆  yzkopsqy maintainer@example.com 2024-03-21 09:46:07 trunk c5dd335b
+│  (empty) Merge pull request #1 from steve/parser
+~
+```
+
+A clean stack again, one PR shorter. Push it, and retarget the `evaluator` PR at
+`trunk` in the GitHub UI, since the branch it used to be based on is about to
+disappear:
+
+```console
+$ jj git push -b evaluator -b cli
+Changes to push to origin:
+  bookmark: cli [move sideways from c3b1a9f61375 to a0bc5b0507af]
+  bookmark: evaluator [move sideways from 5a6f2c6aa13c to 263f373c557b]
+```
+
+Then tidy up the bookmark for the PR that merged. `jj bookmark delete` marks it,
+and the push carries the deletion to the remote:
+
+```console
+$ jj bookmark delete parser
+Deleted 1 bookmarks.
+$ jj git push --deleted
+Changes to push to origin:
+  bookmark: parser [delete from 3b550959d7d9]
+```
+
+## Is this worth it?
+
+For a two-part change, I would probably open one pull request. A stack becomes
+more useful when we have several dependent pieces and a reviewer who would
+rather look at them one at a time.
+
+It's also worth noticing that we didn't need a command specifically for stacked
+pull requests. We used `jj new`, `jj edit`, `jj bookmark`, `jj rebase`, and
+`jj git push`, just as we did in the earlier chapters. The workflow comes from
+combining those familiar commands in a different way.

--- a/src/advanced/working-alongside-git.md
+++ b/src/advanced/working-alongside-git.md
@@ -191,7 +191,7 @@ changed except the new `.jj` directory next to it, so if `jj` turns out not to
 be for you, deleting `.jj` puts everything back.
 
 One gotcha to check first: `git` has two formats for storing refs, and `jj`
-0.44 can only read the older `files` format. On a repository using the newer
+0.45 can only read the older `files` format. On a repository using the newer
 `reftable` format, `jj git init` appears to succeed but imports *nothing* — no
 bookmarks, and a working copy that claims every file is newly added. If you
 see that, don't panic, and don't commit anything: delete the freshly created

--- a/src/advanced/working-alongside-git.md
+++ b/src/advanced/working-alongside-git.md
@@ -167,6 +167,44 @@ For the record, one thing that *isn't* a hazard: `jj` keeps `.jj` out of `git`
 with its own `.gitignore` inside that directory, so a stray `git add -A` can't
 swallow `jj`'s internal state.
 
+## Adopting an existing `git` repository
+
+Everything in this book started life as a `jj` repository, but the other
+direction works too: run `jj git init` inside an existing `git` checkout, and
+`jj` adopts it in place:
+
+```console
+$ jj git init
+Done importing changes from the underlying Git repo.
+Initialized repo in "."
+$ jj log
+@  syomluky steve@steveklabnik.com 2024-03-24 10:12:08 c23e3885
+│  (empty) (no description set)
+○  ypzkvlqw steve@steveklabnik.com 2024-03-24 10:11:52 main 9283911f
+│  existing history
+◆  zzzzzzzz root() 00000000
+```
+
+The history comes across, branches become bookmarks, and a fresh empty `@`
+lands on top of wherever `HEAD` was. Nothing about the `git` repository is
+changed except the new `.jj` directory next to it, so if `jj` turns out not to
+be for you, deleting `.jj` puts everything back.
+
+One gotcha to check first: `git` has two formats for storing refs, and `jj`
+0.44 can only read the older `files` format. On a repository using the newer
+`reftable` format, `jj git init` appears to succeed but imports *nothing* — no
+bookmarks, and a working copy that claims every file is newly added. If you
+see that, don't panic, and don't commit anything: delete the freshly created
+`.jj` directory, migrate the refs, and initialize again:
+
+```console
+$ git rev-parse --show-ref-format
+reftable
+$ git refs migrate --ref-format=files
+```
+
+Most repositories are `files` and adopt cleanly.
+
 ## If you'd rather fence `git` off
 
 Colocation trades a small cost — the import/export on every command, and the odd

--- a/src/advanced/working-alongside-git.md
+++ b/src/advanced/working-alongside-git.md
@@ -1,0 +1,175 @@
+# Working alongside `git`
+
+Every repository in this book is colocated: a `.jj` directory and a real `.git`
+directory over one working copy. This is the default because it lets the rest
+of our toolchain keep working. `gh`, our editor, CI, and plain `git` all see an
+ordinary `git` repository. Let's look at the rules that keep the two views in
+sync.
+
+## Everything syncs on every command
+
+`jj` imports from `git` and exports to it at the start and end of nearly every
+command. We don't need to run `jj git import` or `jj git export` by hand in a
+colocated repository; it happens for us. That means `git log` shows the commits
+we made with `jj`:
+
+```console
+$ git log --oneline
+c4b8fac hello world
+```
+
+And a `jj` *bookmark* is a `git` branch. Move a bookmark in `jj` and the branch
+moves when the command exports it. Create a branch with `git` and a bookmark of
+the same name appears the next time `jj` imports it. They are two names for one
+ref.
+
+## `git HEAD` points at a *parent* of `@`
+
+`git` has a current branch and a `HEAD`. `jj` has neither. To bridge the gap,
+`jj` keeps `git`'s `HEAD` detached, pointing at a *parent* of our working-copy
+commit `@`. Most of the time this is invisible. It stops being invisible after
+`jj edit` on a commit that already has content:
+
+```console
+$ jj edit 'description(glob:"add feature*")'
+$ git status --short
+ M src/feature.rs
+```
+
+`git` reports `src/feature.rs` as modified. It is not uncommitted work. `@` is a
+finished commit whose files are checked out, `HEAD` points at its parent, and
+`git` is honestly reporting the difference between the two. `jj` already has the
+change recorded.
+
+When we're done editing that commit, we can move `@` back on top:
+
+```console
+$ jj new
+```
+
+Now `@` is a fresh empty change, `HEAD` sits at its parent, and `git status` is
+clean again without moving any bookmark or touching pushed history. The same
+thing happens with `jj commit`, which closes `@` and opens a new empty one for
+us. If we leave a non-empty change in `@`, `git`-facing tools will report the
+working tree as dirty. Finishing with `jj new` or `jj commit` makes it clean.
+
+## Let `jj` do the mutating
+
+Both tools write to the same object store. If they write at once, their import
+and export steps can race. There are two rules I follow:
+
+* Don't run `git` and `jj` at the same time against one repository. Run one,
+  then the other.
+* Prefer `jj` for anything that changes history, such as committing, merging,
+  or rebasing.
+  `jj` ignores `git`'s staging area and can't model a half-finished `git rebase`
+  or an unresolved `git` index conflict. A `git` mutation that *completes*
+  cleanly can usually be imported afterwards, but never hand `jj` an operation
+  `git` left in progress.
+
+Reading with `git` is safe. We can use `git log`, `git show`, `git status`, or
+`git diff` whenever they are useful.
+
+## What happens if you mutate with `git` anyway
+
+This doesn't mean that every `git` mutation corrupts the repository. Completed
+operations can often be imported successfully, but they make the interaction
+more complicated. Let's see what actually happens.
+
+A `git` commit that *finishes* is imported on the next `jj` command. `git` keeps
+`HEAD` detached; attach it to a branch first if you want the commit to have a
+bookmark when `jj` imports it:
+
+```console
+$ git checkout -b gitwork
+$ echo change > f.txt && git add f.txt && git commit -m "made by raw git"
+$ jj log
+Reset the working copy parent to the new Git HEAD.
+Done importing changes from the underlying Git repo.
+```
+
+`jj` picked up the commit as an ordinary change, with `gitwork` as a bookmark,
+and put a fresh empty `@` on top. Excellent! In this case, everything came
+across cleanly.
+
+Now the sharper edge. A `git reset --hard` that moves the branch backwards is
+imported too:
+
+```console
+$ git reset --hard <earlier-commit>
+$ jj log
+Reset the working copy parent to the new Git HEAD.
+Done importing changes from the underlying Git repo.
+```
+
+The Git branch and `@` now follow the earlier commit, but commits that `jj`
+already knew about remain as anonymous heads. We can find them with `jj log`,
+or explicitly with `jj log -r 'heads(all())'` if our log revset hides them, and
+point the bookmark back at the change we want:
+
+```console
+$ jj bookmark set gitwork -r <discarded-change>
+```
+
+`jj undo` and `jj op restore` can also reverse imported Git movements. Inspect
+`jj op log` first: importing Git's `HEAD` and refs can produce separate
+operations, so the operation before the reset is a more reliable target than
+assuming one `jj undo` is enough. Data that `jj` never snapshotted is a different
+matter: `git reset --hard` can still destroy uncommitted working-tree changes.
+
+The failure mode the `jj` docs warn about is subtler than lost data: interleaving
+`git` and `jj` mutations can leave a bookmark whose `git` position and `jj`
+position disagree. `jj` then shows the Git-side position separately as
+`name@git`. The conflict itself never loses data, but untangling it is a chore,
+and an editor's automatic `git fetch` can trigger it without you typing
+anything. The cure is the same: prefer `jj` for the mutation, and reach for
+`jj undo` when `git` got there first.
+
+## Two cases to avoid
+
+Most completed `git` mutations import cleanly, as above. Two cases don't,
+because `jj` snapshots the working copy without understanding the state that
+an unfinished Git operation keeps in `.git`.
+
+First, never hand `jj` a `git` operation that's still in progress. A
+`git rebase`, `git merge`, or `git cherry-pick` that hits a conflict stops and
+waits, leaving conflict markers in your files and its own state under `.git`.
+`jj` knows none of that. The next `jj` command snapshots those files as they sit
+— and the raw markers become plain text inside `@`, *not* a `jj` conflict:
+
+```console
+$ git rebase B          # conflicts, and stops half-done
+$ jj st
+Working copy changes:
+M f.txt
+$ jj file show -r @ f.txt
+<<<<<<< HEAD
+BBB
+=======
+AAA
+>>>>>>> 1ce7f83 (A change)
+```
+
+Those `<<<<<<<` lines are committed content now, `jj` sees an ordinary edit
+rather than a conflict, and `git` still thinks the rebase is running. Finish the
+`git` operation or `git rebase --abort` it *before* you run a single `jj`
+command. Otherwise, `jj` will record the conflict markers as ordinary file
+contents rather than as a conflict.
+
+Second, the `git` index is invisible to `jj`. `jj` has no staging area and
+ignores `git`'s. `git add`, and especially `git add -p` to stage part of a file,
+do nothing `jj` respects — `jj` snapshots the whole working tree no matter
+what's staged. Use
+[`jj split`](../real-world-workflows/splitting-changes.md) or `jj squash -i` to
+pick apart a change instead.
+
+For the record, one thing that *isn't* a hazard: `jj` keeps `.jj` out of `git`
+with its own `.gitignore` inside that directory, so a stray `git add -A` can't
+swallow `jj`'s internal state.
+
+## If you'd rather fence `git` off
+
+Colocation trades a small cost — the import/export on every command, and the odd
+confusing intermediate state above — for zero-friction interop. If you'd rather
+`git` couldn't interfere at all, you can hide it entirely. That's the subject of
+[Non-colocated repositories](non-colocated-repos.md).

--- a/src/advanced/workspaces.md
+++ b/src/advanced/workspaces.md
@@ -1,0 +1,140 @@
+# Workspaces
+
+Two chapters ago, we worked on several branches at once without leaving our
+working copy, by editing commits directly. That covers most of what people use
+`git` branch switching for. Sometimes, though, we really do want two directories
+on disk at the same time.
+
+For example, we may want a long build or test run in one tree while we keep
+editing in another. We may also want two versions of the code open side by side,
+or a scratch checkout for a tool that does a lot of work whenever files change.
+
+`git` calls these worktrees. `jj` calls them workspaces.
+
+## Making one
+
+```console
+$ jj workspace add ../feature-b
+Created workspace in "../feature-b"
+Working copy  (@) now at: omvuuyon b1c8e7a0 (empty) (no description set)
+Parent commit (@-)      : posvwlwz 6c45c26f initial
+Added 1 files, modified 0 files, removed 0 files
+```
+
+There's now a second working directory at `../feature-b`, backed by the same
+repository. It got its own fresh empty change, `omvuuyon`. This is the important
+part: *each workspace has its own `@`*.
+
+```console
+$ jj workspace list
+default: . vtmvqlrp 825c9b05 feature a
+feature-b: ../feature-b omvuuyon b1c8e7a0 (empty) (no description set)
+```
+
+The workspace we started in is called `default`. Our new one took its name from
+the directory. We can use `--name` to pick a different name, and `-r` to start
+at a revision other than the default one.
+
+The log shows both, marked with `@` suffixed by the workspace name:
+
+```console
+$ jj log
+@  vtmvqlrp steve@steveklabnik.com 2024-03-23 11:04:16 default@ 825c9b05
+│  feature a
+│ ○  omvuuyon steve@steveklabnik.com 2024-03-23 11:04:16 feature-b@ b1c8e7a0
+├─╯  (empty) (no description set)
+○  posvwlwz steve@steveklabnik.com 2024-03-23 11:03:52 6c45c26f
+│  initial
+◆  zzzzzzzz root() 00000000
+```
+
+`default@` is our working copy; `feature-b@` is the other workspace's. Two
+anonymous branches, two directories, one repository.
+
+Now let's `cd ../feature-b`. It behaves like any other `jj` repository, with the
+same history, bookmarks, and operation log. Work we do here is visible from the
+other workspace immediately, because there's only one repository underneath.
+
+```console
+$ jj st
+Working copy changes:
+A b.txt
+Working copy  (@) : omvuuyon 66ff7d1e feature b
+Parent commit (@-): posvwlwz 6c45c26f initial
+```
+
+## What it isn't
+
+`git worktree` makes you assign a branch to each tree, and refuses to check out
+a branch that's already checked out somewhere else. None of that applies here.
+A workspace just points its `@` at a revision. There's no branch to reserve and
+nothing to be exclusive about.
+
+There is one rule to remember: we shouldn't edit the *same* commit from two
+workspaces. `jj` doesn't forbid it, but both directories would then hold files
+claiming to be the same commit, and whichever one snapshots last would win.
+
+## Stale working copies
+
+Workspaces share history, so a rewrite in one can affect another workspace's
+`@`. Let's say we rebase or abandon a commit that another workspace is sitting
+on. That workspace will fall behind:
+
+```console
+$ jj st
+Error: The working copy is stale (not updated since operation 8f799e48797c).
+Hint: Run `jj workspace update-stale` to update it.
+```
+
+Nothing has been damaged. The repository knows exactly where that commit went;
+the files on disk just haven't caught up yet. We can update them as the hint
+suggests:
+
+```console
+$ jj workspace update-stale
+Working copy  (@) now at: omvuuyon 08f28542 renamed from elsewhere
+Parent commit (@-)      : vtmvqlrp 825c9b05 feature a
+Added 1 files, modified 0 files, removed 0 files
+Updated working copy to fresh commit 08f28542e3a9
+```
+
+The change ID is unchanged — `omvuuyon` is the same change it always was — and
+any uncommitted edits in that directory are still there. It's the same change,
+in its new position.
+
+Not every rewrite makes a workspace stale. If we change a description from
+somewhere else, we haven't touched any files, so the next command in the other
+workspace absorbs it without comment. Staleness is about the files on disk
+disagreeing with the commit they represent. If we'd rather update them
+automatically, we can set `snapshot.auto-update-stale = true` in our config.
+
+## Cleaning up
+
+Deleting the directory isn't enough, because the repository still has the
+workspace registered. Cleanup takes two steps, in either order:
+
+```console
+$ jj workspace forget feature-b
+$ rm -rf ../feature-b
+```
+
+`forget` unregisters the workspace and leaves the directory alone. The commits
+that workspace made are ordinary commits and stay in the repository; only the
+`feature-b@` marker goes away.
+
+One more command worth knowing, mostly for scripts:
+
+```console
+$ jj workspace root
+/home/steve/src/my-project
+```
+
+That's the top of the current workspace, wherever in the tree you happen to be
+standing.
+
+## When to reach for one
+
+Workspaces cost a full checkout on disk and a little bookkeeping. If we only
+need to move between pieces of work, editing commits in one directory is
+simpler. I reach for a workspace when I genuinely need two trees at once, such
+as something long-running in one while I keep working in the other.

--- a/src/branching-merging-and-conflicts/anonymous-branches.md
+++ b/src/branching-merging-and-conflicts/anonymous-branches.md
@@ -125,21 +125,21 @@ We can see that there's a branch in the output of `jj log`:
 
 ```console
 $ jj log
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 │  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
-◉  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40.000 -06:00 ed71bb54
+○  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40 ed71bb54
 │  print goodbye as well as hello
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 We've got our two changes, and there's a fork in the road.
@@ -163,11 +163,11 @@ We do it like this:
 
 ```console
 > jj log -r 'heads(all())'
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 │  (empty) create hello and goodbye functions
 ~
 
-◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 │  (empty) add better documentation
 ~
 ```

--- a/src/branching-merging-and-conflicts/anonymous-branches.md
+++ b/src/branching-merging-and-conflicts/anonymous-branches.md
@@ -55,8 +55,8 @@ use `jj new` to create one. We want to start from a blank slate here.
 
 ```console
 $ jj new
-Working copy now at: yykpmnuq 0bc7a425 (empty) (no description set)
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: yykpmnuq 0bc7a425 (empty) (no description set)
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 A common reason for branching is to work on two different ideas at once. Let's
@@ -68,8 +68,8 @@ to be working on that:
 
 ```console
 > jj describe -m "add better documentation"
-Working copy now at: yykpmnuq 4a95c1f9 (empty) add better documentation
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: yykpmnuq 4a95c1f9 (empty) add better documentation
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 Next, we want to make a change to work on our hello and goodbye functions.
@@ -77,8 +77,8 @@ We want this change to build on top of `ootnlvpt`, so we can just say that:
 
 ```console
 $ jj new o
-Working copy now at: xrslwzvq e9249c85 (empty) (no description set)
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: xrslwzvq e9249c85 (empty) (no description set)
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 We want to create our new change with the parent `o`, which we could see is the
@@ -90,8 +90,8 @@ Let's describe this one too:
 
 ```console
 $ jj describe -m "create hello and goodbye functions"
-Working copy now at: xrslwzvq a70d464c (empty) create hello and goodbye functions
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: xrslwzvq a70d464c (empty) create hello and goodbye functions
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 Excellent. We've got two different changes, `yykpmnuq` and `xrslwzvq`, both with

--- a/src/branching-merging-and-conflicts/anonymous-branches.md
+++ b/src/branching-merging-and-conflicts/anonymous-branches.md
@@ -40,11 +40,21 @@ both would be "on a branch," because everything is on some sort of branch in
 Git considers any commit that's not part of a branch to be garbage, and so
 will garbage collect those commits at some point. Git is very branch-centric.
 
-`jj` does not think about the world this way. Consider the diagram above: we
-didn't name any of these branches, yet the diagram still made sense. There's not
-really an inherent need to name our branches, just like there isn't an inherent
-need to describe our changes. That said, it would be nice to know how to refer
-to different branches, even if they're not named.
+`jj` does not think about the world this way. It keeps track of the head of
+every branch — whether or not a bookmark names it — as part of the visible state
+of our repository. So an anonymous branch is in no danger of being collected: as
+long as a commit shows up in our log, `jj` holds onto it, no bookmark required. A commit only
+becomes a candidate for garbage collection once we hide it, by abandoning it or
+rewriting it — and even then the operation log keeps it around for a while, as
+we'll see [later](../fixing-problems/the-operation-log.md). This is the reverse
+of Git's default: there, a commit stays alive because a branch points at it, and
+here, a commit stays alive because we can still see it.
+
+Consider the diagram above: we didn't name any of these branches, yet the
+diagram still made sense. There's not really an inherent need to name our
+branches, just like there isn't an inherent need to describe our changes. That
+said, it would be nice to know how to refer to different branches, even if
+they're not named.
 
 Let's see how this works.
 

--- a/src/branching-merging-and-conflicts/anonymous-branches.md
+++ b/src/branching-merging-and-conflicts/anonymous-branches.md
@@ -125,14 +125,14 @@ We can see that there's a branch in the output of `jj log`:
 
 ```console
 $ jj log
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
-│  (empty) create hello and goodbye functions
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 e78a9350
+│  create hello and goodbye functions
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ○  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40 ed71bb54
 │  print goodbye as well as hello
 ○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
@@ -163,8 +163,8 @@ We do it like this:
 
 ```console
 > jj log -r 'heads(all())'
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
-│  (empty) create hello and goodbye functions
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 e78a9350
+│  create hello and goodbye functions
 ~
 
 ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -346,6 +346,8 @@ Great, we've cleaned that up.
 
 These behaviors, namely recording conflicts and automatic rebasing, form the
 behaviors necessary for a very cool `jj` workflow, and that's stacking pull
-requests. We'll get to it in the "More advanced workflows" section. Before we
-can talk about that though, we have to talk about how to use `jj` with GitHub
-in the first place! Let's go over that next.
+requests. We'll get to it in the "More advanced workflows" section.
+
+We fixed this conflict by editing the markers out of the file ourselves. Next,
+the other way of going about it: handing the file to a merge tool with
+`jj resolve`.

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -346,5 +346,6 @@ Great, we've cleaned that up.
 
 These behaviors, namely recording conflicts and automatic rebasing, form the
 behaviors necessary for a very cool `jj` workflow, and that's stacking pull
-requests. Before we talk about that though, we have to talk about how to
-use `jj` with GitHub in the first place! Let's go over that next.
+requests. We'll get to it in the "More advanced workflows" section. Before we
+can talk about that though, we have to talk about how to use `jj` with GitHub
+in the first place! Let's go over that next.

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -84,7 +84,7 @@ Excellent:
 $ jj log --limit 3
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
-│ ×  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
+│ ○  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
 ├─╯  remove goodbye message
 ○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
@@ -319,7 +319,7 @@ So fix the conflict in `main.rs` again, and then let's see what happens:
 ```console
 > jj log --limit 4
 Rebased 1 descendant commits onto updated working copy.
-×  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
+○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
 │  (empty) (no description set)
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -82,11 +82,11 @@ Excellent:
 
 ```console
 $ jj log --limit 3
-@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12.000 -06:00 5f858c15
+@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
-│ ◉  povouosx steve@steveklabnik.com 2024-03-01 17:27:14.000 -06:00 28010506
+│ ○  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
 ├─╯  remove goodbye message
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -111,11 +111,11 @@ as there's only one commit that starts like this.)
 
 ```console
 > jj log --limit 3
-◉  povouosx steve@steveklabnik.com 2024-03-01 17:30:32.000 -06:00 793ce8e0 conflict
+○  povouosx steve@steveklabnik.com 2024-03-01 17:30:32 793ce8e0 conflict
 │  remove goodbye message
-@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12.000 -06:00 5f858c15
+@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -151,11 +151,11 @@ And then we check our log again:
 ```console
 $ jj log --limit 3
 Rebased 1 descendant commits onto updated working copy
-◉  povouosx steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 a912c809 conflict
+○  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
 │  remove goodbye message
-@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+@  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -246,11 +246,11 @@ M src/main.rs
 Working copy  (@) : povouosx 7647f7a0 remove goodbye message
 Parent commit (@-): vvmrvwuz d41c079b refactor printing
 $ jj log --limit 3
-@  povouosx steve@steveklabnik.com 2024-03-01 18:08:23.000 -06:00 7647f7a0
+@  povouosx steve@steveklabnik.com 2024-03-01 18:08:23 7647f7a0
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -277,13 +277,13 @@ Added 0 files, modified 1 files, removed 0 files
 > jj new povouosxlror --no-edit
 Created new commit mlzwmxzs 07bb727d (conflict) (empty) (no description set)
 > jj log --limit 4
-◉  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:10:08.000 -06:00 07bb727d conflict
+○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:10:08 07bb727d conflict
 │  (empty) (no description set)
-@  povouosx steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 a912c809 conflict
+@  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 
@@ -293,13 +293,13 @@ So fix the conflict in `main.rs` again, and then let's see what happens:
 ```console
 > jj log --limit 4
 Rebased 1 descendant commits onto updated working copy
-◉  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 9a4ad229
+○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
 │  (empty) (no description set)
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
+@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36.000 -06:00 2b93da0c
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
 ```
 

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -84,7 +84,7 @@ Excellent:
 $ jj log --limit 3
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
-│ ○  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
+│ ×  povouosx steve@steveklabnik.com 2024-03-01 17:27:14 28010506
 ├─╯  remove goodbye message
 ○  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
 │  (empty) add better documentation
@@ -95,23 +95,22 @@ our refactor printing change:
 
 ```console
 $ jj rebase -r povouosx -o @
-New conflicts appeared in these commits:
+Rebased 1 commits to destination.
+New conflicts appeared in 1 commits:
   povouosx 793ce8e0 (conflict) remove goodbye message
-To resolve the conflicts, start by updating to it:
-  jj new povouosxlror
+Hint: To resolve the conflicts, start by creating a commit on top of
+the conflicted commit:
+  jj new povouosx
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 ```
 
 Wait a minute, I thought I told you that rebases always succeed. Well... it did:
-(And, as an aside, `povouosxlror` is giving a few more letters of the change ID
-than `povouosx` used elsewhere. Both can be used interchangeably at this point
-as there's only one commit that starts like this.)
 
 ```console
 > jj log --limit 3
-○  povouosx steve@steveklabnik.com 2024-03-01 17:30:32 793ce8e0 conflict
+×  povouosx steve@steveklabnik.com 2024-03-01 17:30:32 793ce8e0 (conflict)
 │  remove goodbye message
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:29:12 5f858c15
 │  refactor printing
@@ -151,7 +150,7 @@ And then we check our log again:
 ```console
 $ jj log --limit 3
 Rebased 1 descendant commits onto updated working copy.
-○  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
+×  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 (conflict)
 │  remove goodbye message
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
@@ -170,10 +169,11 @@ automatically.
 The output we got back when the conflict was created gave us some advice:
 
 ```text
-To resolve the conflicts, start by updating to it:
-  jj new povouosxlror
+Hint: To resolve the conflicts, start by creating a commit on top of
+the conflicted commit:
+  jj new povouosx
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 ```
 
@@ -188,6 +188,8 @@ remove the conflict markers directly:
 Working copy  (@) now at: povouosx a912c809 (conflict) remove goodbye message
 Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 Added 0 files, modified 1 files, removed 0 files
+Warning: There are unresolved conflicts at these paths:
+src/main.rs    2-sided conflict
 ```
 
 Here's `src/main.rs`:
@@ -198,29 +200,50 @@ Here's `src/main.rs`:
 /// This is the best implementation of this program to ever exist.
 
 fn main() {
-<<<<<<<
-+++++++
+<<<<<<< conflict 1 of 1
++++++++ vvmrvwuz d41c079b "refactor printing" (rebase destination)
     print("Hello, world!");
     print("Goodbye, world!");
-%%%%%%%
-     print_hello();
--    print_goodbye();
->>>>>>>
 }
 
 // a function that prints a message
 fn print(m: &str) {
     println!("{m}")
 }
+%%%%%%% diff from: yykpmnuq 2b93da0c "add better documentation" (parents of rebased revision)
+\\\\\\\        to: povouosx 28010506 "remove goodbye message" (rebased revision)
+     print_hello();
+-    print_goodbye();
+ }
+ 
+ fn print_hello() {
+     println!("Hello, world!");
+ }
+-
+-fn print_goodbye() {
+-    println!("Goodbye, world!");
+-}
+>>>>>>> conflict 1 of 1 ends
 ```
 
 `git` uses a combination of `<<<<`, `=====`, and `>>>>` to mark conflicts. `jj`
-has more rich conflict markers. It still uses the `>>>` and `<<<`s to indicate
-the start and end, but has two other markers: `+++++++` and `%%%%%%%`. The `+`s
-indicate the start of a snapshot, and `%`s mark the start of a diff. So we can
-see that we have two `print` lines, but our changes wanted to remove one of them,
-but since that's not the same thing, conflict. To resolve this, we apply our own
-take on the diff to the snapshot:
+has richer conflict markers. It still uses the `>>>` and `<<<`s to indicate the
+start and end, but has two others: `+++++++` marks a snapshot, and `%%%%%%%`
+marks a diff. Each one is labelled with the commit it came from, which is what
+makes them readable.
+
+So: the snapshot is the destination we rebased onto, `vvmrvwuz`, verbatim. Then
+the diff is our own change, expressed as what `povouosx` did to its old parent
+`yykpmnuq` — it dropped the `print_goodbye()` call and the whole
+`print_goodbye` function. `jj` couldn't apply that diff to that snapshot,
+because the lines it wanted to remove aren't there any more; `vvmrvwuz` rewrote
+them into `print(...)` calls. So it hands you both halves and lets you do it.
+
+Notice how much of the file is inside the conflict region. `jj` isn't
+conflicting on one line — the diff and the snapshot overlap across most of
+`main()` and the functions below it, so the whole span gets marked.
+
+To resolve this, we apply our own take on the diff to the snapshot:
 
 ```rust
 /// A "Hello, world!" program.
@@ -264,22 +287,25 @@ and then we'll make a new change on top of our conflicted change:
 
 ```console
 > jj undo
-New conflicts appeared in these commits:
+Undid operation: 3c9a71fd50e2 (2024-03-01 18:08:23) snapshot working copy
+Restored to operation: 8b40cc21ae77 (2024-03-01 17:49:07) snapshot working copy
+New conflicts appeared in 1 commits:
   povouosx a912c809 (conflict) remove goodbye message
-To resolve the conflicts, start by updating to it:
-  jj new povouosxlror
+Hint: To resolve the conflicts, start by creating a commit on top of
+the conflicted commit:
+  jj new povouosx
 Then use `jj resolve`, or edit the conflict markers in the file directly.
-Once the conflicts are resolved, you may want inspect the result with `jj diff`.
+Once the conflicts are resolved, you can inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
 Working copy  (@) now at: povouosx a912c809 (conflict) remove goodbye message
 Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 Added 0 files, modified 1 files, removed 0 files
-> jj new povouosxlror --no-edit
+> jj new povouosx --no-edit
 Created new commit mlzwmxzs 07bb727d (conflict) (empty) (no description set)
 > jj log --limit 4
-○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:10:08 07bb727d conflict
+×  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:10:08 07bb727d (conflict)
 │  (empty) (no description set)
-@  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
+@  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 (conflict)
 │  remove goodbye message
 ○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
@@ -293,7 +319,7 @@ So fix the conflict in `main.rs` again, and then let's see what happens:
 ```console
 > jj log --limit 4
 Rebased 1 descendant commits onto updated working copy.
-○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
+×  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
 │  (empty) (no description set)
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
@@ -312,7 +338,8 @@ right now:
 
 ```console
 $ jj abandon mlzwmxzs
-Abandoned commit mlzwmxzs 9a4ad229 (empty) (no description set)
+Abandoned 1 commits:
+  mlzwmxzs 9a4ad229 (empty) (no description set)
 ```
 
 Great, we've cleaned that up.

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -9,8 +9,8 @@ Let's deliberately introduce a conflict. First, we make a new change:
 
 ```console
 $ jj new -m "remove goodbye message"
-Working copy now at: povouosx e2c9628c (empty) remove goodbye message
-Parent commit      : yykpmnuq 2b93da0c (empty) add better documentation
+Working copy  (@) now at: povouosx e2c9628c (empty) remove goodbye message
+Parent commit (@-)      : yykpmnuq 2b93da0c (empty) add better documentation
 ```
 
 And then update `src/main.rs` appropriately:
@@ -33,8 +33,8 @@ Let's also make a new change off of the previous head:
 
 ```console
 $ jj new yykpmnuq -m "refactor printing"
-Working copy now at: vvmrvwuz 44205653 (empty) refactor printing
-Parent commit      : yykpmnuq 2b93da0c (empty) add better documentation
+Working copy  (@) now at: vvmrvwuz 44205653 (empty) refactor printing
+Parent commit (@-)      : yykpmnuq 2b93da0c (empty) add better documentation
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -185,8 +185,8 @@ remove the conflict markers directly:
 
 ```console
 > jj edit povouosx
-Working copy now at: povouosx a912c809 (conflict) remove goodbye message
-Parent commit      : vvmrvwuz d41c079b refactor printing
+Working copy  (@) now at: povouosx a912c809 (conflict) remove goodbye message
+Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -243,8 +243,8 @@ Let's take a look:
 $ jj st
 Working copy changes:
 M src/main.rs
-Working copy : povouosx 7647f7a0 remove goodbye message
-Parent commit: vvmrvwuz d41c079b refactor printing
+Working copy  (@) : povouosx 7647f7a0 remove goodbye message
+Parent commit (@-): vvmrvwuz d41c079b refactor printing
 $ jj log --limit 3
 @  povouosx steve@steveklabnik.com 2024-03-01 18:08:23.000 -06:00 7647f7a0
 │  remove goodbye message
@@ -271,8 +271,8 @@ To resolve the conflicts, start by updating to it:
 Then use `jj resolve`, or edit the conflict markers in the file directly.
 Once the conflicts are resolved, you may want inspect the result with `jj diff`.
 Then run `jj squash` to move the resolution into the conflicted commit.
-Working copy now at: povouosx a912c809 (conflict) remove goodbye message
-Parent commit      : vvmrvwuz d41c079b refactor printing
+Working copy  (@) now at: povouosx a912c809 (conflict) remove goodbye message
+Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 Added 0 files, modified 1 files, removed 0 files
 > jj new povouosxlror --no-edit
 Created new commit mlzwmxzs 07bb727d (conflict) (empty) (no description set)

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -150,7 +150,7 @@ And then we check our log again:
 
 ```console
 $ jj log --limit 3
-Rebased 1 descendant commits onto updated working copy
+Rebased 1 descendant commits onto updated working copy.
 ○  povouosx steve@steveklabnik.com 2024-03-01 17:49:07 a912c809 conflict
 │  remove goodbye message
 @  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
@@ -292,7 +292,7 @@ So fix the conflict in `main.rs` again, and then let's see what happens:
 
 ```console
 > jj log --limit 4
-Rebased 1 descendant commits onto updated working copy
+Rebased 1 descendant commits onto updated working copy.
 ○  mlzwmxzs steve@steveklabnik.com 2024-03-01 18:12:43 9a4ad229
 │  (empty) (no description set)
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -242,7 +242,7 @@ Let's take a look:
 ```console
 $ jj st
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : povouosx 7647f7a0 remove goodbye message
 Parent commit: vvmrvwuz d41c079b refactor printing
 $ jj log --limit 3

--- a/src/branching-merging-and-conflicts/conflicts.md
+++ b/src/branching-merging-and-conflicts/conflicts.md
@@ -194,7 +194,7 @@ src/main.rs    2-sided conflict
 
 Here's `src/main.rs`:
 
-```rust
+```rust,ignore
 /// A "Hello, world!" program.
 /// 
 /// This is the best implementation of this program to ever exist.

--- a/src/branching-merging-and-conflicts/intro.md
+++ b/src/branching-merging-and-conflicts/intro.md
@@ -13,3 +13,4 @@ Here's what we're going to learn:
 * Figuring out where our changes are with revsets
 * Merging anonymous branches
 * Dealing with conflicts
+* Resolving them with `jj resolve`

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -105,8 +105,9 @@ $ jj log --limit 5
 │  refactor printing
 ```
 
-That's right, we can undo our last command with a simple `jj undo`. We'll talk
-about it more in the future. But for now, it's like our merge never happened.
+That's right, we can undo our last command with a simple `jj undo`. There's a
+whole section on this later — "Fixing Problems" — because it goes much deeper
+than it looks. For now, it's like our merge never happened.
 
 Let's try merging all three in at the same time:
 

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -4,8 +4,8 @@ Let's recall where we are:
 
 ```console
 > jj log
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
-│  (empty) create hello and goodbye functions
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 e78a9350
+│  create hello and goodbye functions
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
@@ -29,14 +29,14 @@ Let's take a look:
 > jj log --limit 5
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
-├─╯  (empty) create hello and goodbye functions
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 e78a9350
+├─╯  create hello and goodbye functions
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 We passed the `--limit` flag so that we didn't see every commit; our history
@@ -71,12 +71,12 @@ choosing six as the limit since we just added a new change:
 │ │  (empty) add better documentation
 ○ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 ├─╯  (empty) added some cool new feature
-│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
-├─╯  (empty) create hello and goodbye functions
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 e78a9350
+├─╯  create hello and goodbye functions
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 We can see the lines connecting to both of our parents, and we can still see
@@ -95,14 +95,14 @@ Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
-├─╯  (empty) create hello and goodbye functions
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 e78a9350
+├─╯  create hello and goodbye functions
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 That's right, we can undo our last command with a simple `jj undo`. There's a
@@ -116,12 +116,13 @@ $ jj new pzoqtwuv yykpmnuq xrslwzvq -m "merge three branches"
 Working copy  (@) now at: vuztuxmz 717232df (empty) merge three branches
 Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
-Parent commit (@-)      : xrslwzvq a70d464c (empty) create hello and goodbye functions
+Parent commit (@-)      : xrslwzvq e78a9350 create hello and goodbye functions
+Added 0 files, modified 1 files, removed 0 files
 $ jj log --limit 6
 @      vuztuxmz steve@steveklabnik.com 2024-03-01 15:38:49 717232df
 ├─┬─╮  (empty) merge three branches
-│ │ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
-│ │ │  (empty) create hello and goodbye functions
+│ │ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 e78a9350
+│ │ │  create hello and goodbye functions
 │ ○ │  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 │ ├─╯  (empty) add better documentation
 ○ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
@@ -129,7 +130,7 @@ $ jj log --limit 6
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 Just as easy as that: a merge commit with three different parents.
@@ -158,14 +159,14 @@ Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
-├─╯  (empty) create hello and goodbye functions
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 e78a9350
+├─╯  create hello and goodbye functions
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 Excellent. Let's keep a linear history by using a rebase instead of a merge.
@@ -189,7 +190,7 @@ Note that the working copy didn't move. Let's look at our log:
 ```console
 $ jj log --limit 5
 ○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
-│  (empty) create hello and goodbye functions
+│  create hello and goodbye functions
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
@@ -197,7 +198,7 @@ $ jj log --limit 5
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 We have rebased our commit successfully. But you may have noticed something
@@ -232,7 +233,7 @@ $ jj log --limit 6
 ○  owlpoptm steve@steveklabnik.com 2024-03-01 16:28:54 df6620cb
 │  (empty) not gonna start this yet
 │ ○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
-├─╯  (empty) create hello and goodbye functions
+├─╯  create hello and goodbye functions
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
@@ -240,7 +241,7 @@ $ jj log --limit 6
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 New change, yet we're still where we are. Let's undo that real quick:
@@ -251,7 +252,7 @@ Undid operation: 7d2b41ac9e08 (2024-03-01 16:28:54) new empty commit
 Restored to operation: 1e5f77c2ab3d (2024-03-01 16:08:37) rebase commit
 $ jj log --limit 5
 ○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
-│  (empty) create hello and goodbye functions
+│  create hello and goodbye functions
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
@@ -259,7 +260,7 @@ $ jj log --limit 5
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 Cool. Okay so that theory sounds cool, and it's nice that it makes things fast,
@@ -268,11 +269,12 @@ but what about when we *do* want to move `@`? Well, the fact that the
 
 ```console
 $ jj edit xrslwzvq
-Working copy  (@) now at: xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
+Working copy  (@) now at: xrslwzvq 6c4afc8f create hello and goodbye functions
 Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
+Added 0 files, modified 1 files, removed 0 files
 $ jj log --limit 5
 @  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
-│  (empty) create hello and goodbye functions
+│  create hello and goodbye functions
 ○  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
 │ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
@@ -280,7 +282,7 @@ $ jj log --limit 5
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 We can now rebase our other change on top too:
@@ -292,13 +294,13 @@ $ jj log --limit 5
 ○  yykpmnuq steve@steveklabnik.com 2024-03-01 16:35:47 7bea29b6
 │  (empty) add better documentation
 @  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
-│  (empty) create hello and goodbye functions
+│  create hello and goodbye functions
 ○  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
 ○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
-│  refactor printing
+│  add more comments
 ```
 
 Excellent. But before we move `@`, I want to show you a little trick. We could
@@ -308,7 +310,7 @@ isn't that hard. But we can also use a revset:
 ```console
 $ jj edit @+
 Working copy  (@) now at: yykpmnuq 7bea29b6 (empty) add better documentation
-Parent commit (@-)      : xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
+Parent commit (@-)      : xrslwzvq 6c4afc8f create hello and goodbye functions
 ```
 
 `+` means "the child of this revision", so `@+` is "the child revision of the

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -112,7 +112,8 @@ Let's try merging all three in at the same time:
 
 ```console
 $ jj new pzoqtwuv yykpmnuq xrslwzvq -m "merge three branches"
-Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Working copy  (@) now at: vuztuxmz 717232df (empty) merge three branches
+Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
 Parent commit (@-)      : xrslwzvq a70d464c (empty) create hello and goodbye functions
 $ jj log --limit 6

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -45,8 +45,8 @@ is already getting a little long.
 ## Merging branches
 
 Now, you may expect that you'd use a command like `jj merge` to merge branches
-together. However, as of `0.14.0`, `jj merge` is deprecated, and will be removed
-some time later this year. So how the heck do we create merges?
+together. There is no such command: it was deprecated in `0.14.0` and has since
+been removed. So how the heck do we create merges?
 
 Well, what is a merge anyway? It's a new change that has more than one parent.
 How do we make new changes? With `jj new`. So let's ask it to make a change that

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -19,8 +19,8 @@ on our main branch while we were doing the work:
 
 ```console
 > jj new o -m "added some cool new feature"
-Working copy now at: pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 ```
 
 Let's take a look:
@@ -54,9 +54,9 @@ has both `pzoqtwuv` and `yykpmnuq` as parents:
 
 ```console
 > jj new pzoqtwuv yykpmnuq -m "merge better documentation"
-Working copy now at: rxzyvnkx f1c1bde8 (empty) merge better documentation
-Parent commit      : pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : yykpmnuq 210283e8 (empty) add better documentation
+Working copy  (@) now at: rxzyvnkx f1c1bde8 (empty) merge better documentation
+Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
 ```
 
 Just like we'd pass a parent revision to `jj new`, we can pass multiple parents,
@@ -88,8 +88,8 @@ I haven't told you about yet:
 
 ```console
 $ jj undo
-Working copy now at: pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
 │  (empty) added some cool new feature
@@ -110,9 +110,9 @@ Let's try merging all three in at the same time:
 
 ```console
 $ jj new pzoqtwuv yykpmnuq xrslwzvq -m "merge three branches"
-Working copy now at: pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : yykpmnuq 210283e8 (empty) add better documentation
-Parent commit      : xrslwzvq a70d464c (empty) create hello and goodbye functions
+Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
+Parent commit (@-)      : xrslwzvq a70d464c (empty) create hello and goodbye functions
 $ jj log --limit 6
 @      vuztuxmz steve@steveklabnik.com 2024-03-01 15:38:49.000 -06:00 717232df
 ├─┬─╮  (empty) merge three branches
@@ -147,8 +147,8 @@ Let's undo our merge again:
 
 ```console
 $ jj undo
-Working copy now at: pzoqtwuv 9353442b (empty) added some cool new feature
-Parent commit      : ootnlvpt b5db7940 only print hello world
+Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
+Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
 @  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
 │  (empty) added some cool new feature
@@ -259,8 +259,8 @@ but what about when we *do* want to move `@`? Well, the fact that the
 
 ```console
 $ jj edit xrslwzvq
-Working copy now at: xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
-Parent commit      : pzoqtwuv 9353442b (empty) added some cool new feature
+Working copy  (@) now at: xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
+Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
 $ jj log --limit 5
 @  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
 │  (empty) create hello and goodbye functions
@@ -297,8 +297,8 @@ isn't that hard. But we can also use a revset:
 
 ```console
 $ jj edit @+
-Working copy now at: yykpmnuq 7bea29b6 (empty) add better documentation
-Parent commit      : xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
+Working copy  (@) now at: yykpmnuq 7bea29b6 (empty) add better documentation
+Parent commit (@-)      : xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
 ```
 
 `+` means "the child of this revision", so `@+` is "the child revision of the

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -4,11 +4,11 @@ Let's recall where we are:
 
 ```console
 > jj log
-@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+@  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 │  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
 ```
 
@@ -27,15 +27,15 @@ Let's take a look:
 
 ```console
 > jj log --limit 5
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 ├─╯  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -65,17 +65,17 @@ choosing six as the limit since we just added a new change:
 
 ```console
 > jj log --limit 6
-@    rxzyvnkx steve@steveklabnik.com 2024-03-01 15:21:11.000 -06:00 f1c1bde8
+@    rxzyvnkx steve@steveklabnik.com 2024-03-01 15:21:11 f1c1bde8
 ├─╮  (empty) merge better documentation
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 │ │  (empty) add better documentation
-◉ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+○ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 ├─╯  (empty) added some cool new feature
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 ├─╯  (empty) create hello and goodbye functions
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -91,15 +91,15 @@ $ jj undo
 Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 ├─╯  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -114,17 +114,17 @@ Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : yykpmnuq 210283e8 (empty) add better documentation
 Parent commit (@-)      : xrslwzvq a70d464c (empty) create hello and goodbye functions
 $ jj log --limit 6
-@      vuztuxmz steve@steveklabnik.com 2024-03-01 15:38:49.000 -06:00 717232df
+@      vuztuxmz steve@steveklabnik.com 2024-03-01 15:38:49 717232df
 ├─┬─╮  (empty) merge three branches
-│ │ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ │ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 │ │ │  (empty) create hello and goodbye functions
-│ ◉ │  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○ │  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 │ ├─╯  (empty) add better documentation
-◉ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+○ │  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 ├─╯  (empty) added some cool new feature
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -150,15 +150,15 @@ $ jj undo
 Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23.000 -06:00 a70d464c
+│ ○  xrslwzvq steve@steveklabnik.com 2024-02-29 23:06:23 a70d464c
 ├─╯  (empty) create hello and goodbye functions
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -181,15 +181,15 @@ We didn't get any output though. Let's look at our log:
 
 ```console
 $ jj log --limit 5
-◉  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -222,17 +222,17 @@ flag you can pass instead to create a new change but not modify `@`:
 $ jj new -m "not gonna start this yet" --no-edit
 Created new commit owlpoptm df6620cb (empty) not gonna start this yet
 $ jj log --limit 6
-◉  owlpoptm steve@steveklabnik.com 2024-03-01 16:28:54.000 -06:00 df6620cb
+○  owlpoptm steve@steveklabnik.com 2024-03-01 16:28:54 df6620cb
 │  (empty) not gonna start this yet
-│ ◉  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+│ ○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 ├─╯  (empty) create hello and goodbye functions
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -241,15 +241,15 @@ New change, yet we're still where we are. Let's undo that real quick:
 ```console
 $ jj undo
 $ jj log --limit 5
-◉  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
-@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+@  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -262,15 +262,15 @@ $ jj edit xrslwzvq
 Working copy  (@) now at: xrslwzvq 6c4afc8f (empty) create hello and goodbye functions
 Parent commit (@-)      : pzoqtwuv 9353442b (empty) added some cool new feature
 $ jj log --limit 5
-@  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+@  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
-◉  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+○  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-│ ◉  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22.000 -06:00 210283e8
+│ ○  yykpmnuq steve@steveklabnik.com 2024-02-29 23:03:22 210283e8
 ├─╯  (empty) add better documentation
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 
@@ -279,15 +279,15 @@ We can now rebase our other change on top too:
 ```console
 $ jj rebase -r yykpmnuq -o xrslwzvq
 $ jj log --limit 5
-◉  yykpmnuq steve@steveklabnik.com 2024-03-01 16:35:47.000 -06:00 7bea29b6
+○  yykpmnuq steve@steveklabnik.com 2024-03-01 16:35:47 7bea29b6
 │  (empty) add better documentation
-@  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37.000 -06:00 6c4afc8f
+@  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
-◉  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59.000 -06:00 9353442b
+○  pzoqtwuv steve@steveklabnik.com 2024-03-01 15:06:59 9353442b
 │  (empty) added some cool new feature
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  refactor printing
 ```
 

--- a/src/branching-merging-and-conflicts/merging.md
+++ b/src/branching-merging-and-conflicts/merging.md
@@ -88,6 +88,8 @@ I haven't told you about yet:
 
 ```console
 $ jj undo
+Undid operation: 4a1f0e6c8b2d (2024-03-01 15:21:11) new empty commit
+Restored to operation: 91c33bb0d5ef (2024-03-01 15:06:59) new empty commit
 Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
@@ -147,6 +149,8 @@ Let's undo our merge again:
 
 ```console
 $ jj undo
+Undid operation: 4a1f0e6c8b2d (2024-03-01 15:21:11) new empty commit
+Restored to operation: 91c33bb0d5ef (2024-03-01 15:06:59) new empty commit
 Working copy  (@) now at: pzoqtwuv 9353442b (empty) added some cool new feature
 Parent commit (@-)      : ootnlvpt b5db7940 only print hello world
 $ jj log --limit 5
@@ -170,6 +174,7 @@ change on top of our current change:
 
 ```console
 $ jj rebase -r xrslwzvq -o pzoqtwuv
+Rebased 1 commits to destination.
 ```
 
 This rebases a single revision with `-r`, *onto* a certain destination revision,
@@ -177,7 +182,7 @@ hence `-o`. Since our branch only had one revision, this would be the same as
 passing `-b xrslwzvq`, which would move the whole branch that revision is on,
 or `-s xrslwzvq`, which rebases that revision as well as all of its descendants.
 
-We didn't get any output though. Let's look at our log:
+Note that the working copy didn't move. Let's look at our log:
 
 ```console
 $ jj log --limit 5
@@ -240,6 +245,8 @@ New change, yet we're still where we are. Let's undo that real quick:
 
 ```console
 $ jj undo
+Undid operation: 7d2b41ac9e08 (2024-03-01 16:28:54) new empty commit
+Restored to operation: 1e5f77c2ab3d (2024-03-01 16:08:37) rebase commit
 $ jj log --limit 5
 ○  xrslwzvq steve@steveklabnik.com 2024-03-01 16:08:37 6c4afc8f
 │  (empty) create hello and goodbye functions
@@ -278,6 +285,7 @@ We can now rebase our other change on top too:
 
 ```console
 $ jj rebase -r yykpmnuq -o xrslwzvq
+Rebased 1 commits to destination.
 $ jj log --limit 5
 ○  yykpmnuq steve@steveklabnik.com 2024-03-01 16:35:47 7bea29b6
 │  (empty) add better documentation

--- a/src/branching-merging-and-conflicts/resolving-conflicts.md
+++ b/src/branching-merging-and-conflicts/resolving-conflicts.md
@@ -1,0 +1,93 @@
+# Resolving conflicts with `jj resolve`
+
+In the last chapter, we resolved a conflict by opening the file and editing the
+markers by hand. That always works, and for a small conflict it's often the
+quickest approach. We can also use `jj resolve`, which hands each conflicted
+file to a merge tool one at a time.
+
+First, let's find out what's actually conflicted:
+
+```console
+$ jj resolve --list
+greeting.txt    2-sided conflict
+```
+
+Two-sided is the ordinary case — two branches, two versions. You'll see
+three-sided and worse if you merge more than two things at once, or conflict on
+top of a conflict.
+
+Then run it:
+
+```console
+$ jj resolve
+```
+
+That opens your merge editor on `greeting.txt`, with the two sides and the base
+version. Save and exit, and `jj` records the result; exit without changing
+anything and it stops, leaving the conflict alone. If several files are
+conflicted, you get them one after another, and you can name paths —
+`jj resolve greeting.txt` — to deal with one at a time.
+
+Which tool opens depends on `ui.merge-editor`, which we'll set in the
+customization section. The default is `jj`'s built-in editor.
+
+## Taking one side wholesale
+
+Sometimes there's nothing to merge because one side is simply right. There are
+two built-in tools that let us skip the editor:
+
+```console
+$ jj resolve --tool :ours
+Working copy  (@) now at: plwvlnst 80d01ccc merge the two
+Parent commit (@-)      : tmqzyrmt ef8a1082 say hi
+Parent commit (@-)      : xvqtknsp 828bdd03 say hey
+```
+
+```console
+$ cat greeting.txt
+hi
+```
+
+`:ours` takes the first side of the conflict, `:theirs` the second. Be careful
+with the names: in a merge, "ours" is the first parent you gave `jj new`, and
+in a rebase it's the commit being rebased onto. Check with `jj diff` afterwards
+rather than trusting the word.
+
+## Resolving somewhere else
+
+Conflicts don't have to be resolved in the working copy. `-r` points `jj resolve`
+at any conflicted commit:
+
+```console
+$ jj resolve -r povouosx
+```
+
+This is worth knowing because `jj`'s hint suggests another approach: make a new
+commit on top of the conflicted one, fix it there, then use `jj squash` to move
+the fix down. Both work. The hint's version keeps the conflicted commit
+untouched while we experiment, while `-r` edits it directly.
+
+## Afterwards
+
+Resolving is just editing, so the usual tools apply. `jj st` stops warning you:
+
+```console
+$ jj st
+Working copy changes:
+M greeting.txt
+Working copy  (@) : plwvlnst 80d01ccc merge the two
+Parent commit (@-): tmqzyrmt ef8a1082 say hi
+Parent commit (@-): xvqtknsp 828bdd03 say hey
+```
+
+`jj diff` shows what you settled on, and `jj undo` puts the conflict back if you
+got it wrong. A resolution is a normal edit to a normal commit, with all the
+same escape hatches.
+
+And as we saw last chapter, resolving a conflict once is enough: descendants get
+rebased onto the resolved version automatically, and the conflict doesn't come
+back for each commit in turn the way it does with `git rebase`.
+
+That's branching, merging, and conflicts covered. Before we can get to the
+stacked pull request workflow those behaviors make possible, we have to talk
+about using `jj` with GitHub in the first place. Let's go over that next.

--- a/src/branching-merging-and-conflicts/resolving-conflicts.md
+++ b/src/branching-merging-and-conflicts/resolving-conflicts.md
@@ -5,6 +5,11 @@ markers by hand. That always works, and for a small conflict it's often the
 quickest approach. We can also use `jj resolve`, which hands each conflicted
 file to a merge tool one at a time.
 
+Since we cleaned up the conflict in our project already, I've made a little
+scratch repository to play with: two changes, "say hi" and "say hey", that
+each put a different greeting in `greeting.txt`, and a merge of the two on
+top. That merge is, of course, conflicted.
+
 First, let's find out what's actually conflicted:
 
 ```console
@@ -56,7 +61,8 @@ rather than trusting the word.
 ## Resolving somewhere else
 
 Conflicts don't have to be resolved in the working copy. `-r` points `jj resolve`
-at any conflicted commit:
+at any conflicted commit. Back in the last chapter, when `povouosx` was sitting
+above us in conflict, we could have fixed it without moving `@` at all:
 
 ```console
 $ jj resolve -r povouosx

--- a/src/branching-merging-and-conflicts/revsets.md
+++ b/src/branching-merging-and-conflicts/revsets.md
@@ -35,6 +35,11 @@ in fact, `jj squash` is short for `jj squash -r @` or equivalently `jj squash
 * `x | y`: changes that are in either x or y
 * `::x` Ancestors of x
 * `x::` Descendants of x
+* `x-`: direct parents of x
+* `x+`: direct children of x
+* `x::y`: descendants of x that are also ancestors of y, including both x and y
+* `x+::y`: paths from direct children of x to y, excluding x and including y
+* `x..y`: ancestors of y that are not ancestors of x, including y but not x
 
 And more. The final bit is the most interesting, and that's functions.
 
@@ -66,6 +71,104 @@ commit by me containing the word "print" in the description? Try this:
 ```console
 $ jj log -r 'author("Steve Klabnik") & description(substring:print)'
 ```
+
+## Selecting a whole anonymous branch
+
+Let's put those operators to work. Suppose we tried one idea for three changes,
+started another idea from the same point, and then decided that we did not want
+the first idea after all. Our history would look like this:
+
+```text
+common ─┬─ n1 ── n2 ── n3
+        ╰─ x1 ── x2 (@)
+```
+
+Here, `common`, `n1`, and the other labels stand for change IDs. The `n` and `x`
+changes form two anonymous branches, but there is no branch marker to delete.
+Even if we had put a bookmark on `n3` and deleted it, `n3` would still be a
+visible head. To make that whole idea disappear from the visible history, we
+need to abandon all three of its changes.
+
+* `n1::n3` is inclusive, including both `n1` and `n3`.
+* `common..n3` excludes `common` and includes `n3`.
+
+We can first ask `jj` to show us what `n3` adds on top of `common`:
+
+```console
+$ jj log -r 'common..n3'
+○  n3
+○  n2
+○  n1
+~
+```
+
+The `..` operator excludes `common`: `common..n3` means "ancestors of `n3` that
+are not ancestors of `common`." In this simple graph, that gives us exactly the
+three changes on the branch we want to abandon. It also leaves `x1` and `x2`
+alone because neither is an ancestor of `n3`.
+
+There is another range operator that looks similar but answers a different
+question. `common::n3` means "changes on a path from `common` to `n3`,"
+including both ends. It selects `common`, `n1`, `n2`, and `n3`, so we must not
+abandon that range: the other branch still needs `common`.
+
+If we know the first change on the unwanted branch, `n1::n3` gives us the exact
+inclusive range from `n1` through `n3`. We can preview that range with `jj log`,
+then abandon it:
+
+```console
+$ jj log -r 'n1::n3'
+○  n3
+○  n2
+○  n1
+~
+$ jj abandon 'n1::n3'
+Abandoned 3 commits:
+  n3
+  n2
+  n1
+```
+
+If we know `common` but not `n1`, `common+::n3` selects the same range. The `+`
+means "direct children of `common`," so this starts after `common`; the `::n3`
+part then keeps only changes on a path to `n3`. If the branch merges history
+that is not descended from `common`, `common..n3` includes that history while
+`common+::n3` excludes it.
+
+The `x1` branch shows where that distinction ends. While it remains separate,
+both `common..n3` and `common+::n3` exclude `x1` because it is not an ancestor
+of `n3`. If `x1` were merged into `n3`, both ranges would include it. It would
+then be an ancestor of `n3` and on a path from a direct child of `common` to
+`n3`.
+`n1::n3` would still exclude `x1`, because `x1` is not a descendant of `n1`.
+If we want only the `n` branch after such a merge, `n1::n3` is the precise
+range to use.
+
+Abandoning only `n3` would not remove the branch. It would merely make `n2` the
+new anonymous head. The other boundary matters too. If an `n4` existed after
+`n3`, abandoning `n1::n3` would not abandon it. `jj` would rebase that surviving
+descendant onto `common` and report:
+
+```console
+Rebased 1 descendant commits onto parents of abandoned commits.
+```
+
+The `n4` change would remain as another anonymous head. If we want to discard an
+entire branch, we therefore need to use its actual first change and tip as the
+range boundaries. In our original graph, where `n3` really is the tip,
+abandoning the whole range leaves this visible graph:
+
+```text
+common ── x1 ── x2 (@)
+```
+
+This hides the commits; it does not immediately erase their objects. `jj`
+records the abandon in the
+[operation log](../fixing-problems/the-operation-log.md), whose earlier states
+keep the hidden commits in the repository. That repository-level history is why
+`jj undo` can restore the branch if abandoning it was a mistake. Once the old
+operations that refer to those commits are themselves abandoned, the commits
+can be removed by later garbage collection.
 
 Another really useful revset function is `trunk()`:
 

--- a/src/branching-merging-and-conflicts/revsets.md
+++ b/src/branching-merging-and-conflicts/revsets.md
@@ -75,10 +75,12 @@ $ jj log -r 'trunk()'
 ```
 
 Right now, this doesn't look very useful, but it will be more useful when we
-get into sharing our changes. `trunk()` looks for a remote named `origin` or
-`upstream`, and looks for a `main`, `master`, or `trunk` branch, and then
-provides that. Since we don't have any of those right now, it gives us the same
-as `root()`.
+get into sharing our changes. `trunk()` resolves to the tip of the shared main
+line of development — in most repositories that's `main@origin`, the `main`
+branch on the `origin` remote. More precisely, it looks for a remote named
+`origin` or `upstream`, looks for a `main`, `master`, or `trunk` branch on it,
+and provides that. Since we don't have any of those right now, it gives us the
+same as `root()`.
 
 Additionally, on the `jj` Discord, several folks have settled on this as a
 decent revset for larger repositories:

--- a/src/branching-merging-and-conflicts/revsets.md
+++ b/src/branching-merging-and-conflicts/revsets.md
@@ -71,7 +71,7 @@ Another really useful revset function is `trunk()`:
 
 ```console
 $ jj log -r 'trunk()'
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 Right now, this doesn't look very useful, but it will be more useful when we

--- a/src/branching-merging-and-conflicts/revsets.md
+++ b/src/branching-merging-and-conflicts/revsets.md
@@ -60,6 +60,13 @@ More complex functions can take arguments:
 * `heads(x)`: commits in `x` that are not ancestors of other commits in `x`
 * `description(substring:x)`: commits that have a substring `x` in their description
 
+That `substring:` prefix on the last one matters, by the way. If you leave it
+off and write `description("print")`, `jj` looks for a description that is
+*exactly* the string `print` — which, since descriptions keep their trailing
+newline, matches nothing at all. A bare string quietly gives you an empty set,
+and whatever command you ran does nothing. Use `substring:` or `glob:` and
+you'll get what you meant.
+
 ## Putting it all together
 
 Now we can understand `heads(all())` from before: these are two functions, where
@@ -71,104 +78,6 @@ commit by me containing the word "print" in the description? Try this:
 ```console
 $ jj log -r 'author("Steve Klabnik") & description(substring:print)'
 ```
-
-## Selecting a whole anonymous branch
-
-Let's put those operators to work. Suppose we tried one idea for three changes,
-started another idea from the same point, and then decided that we did not want
-the first idea after all. Our history would look like this:
-
-```text
-common ─┬─ n1 ── n2 ── n3
-        ╰─ x1 ── x2 (@)
-```
-
-Here, `common`, `n1`, and the other labels stand for change IDs. The `n` and `x`
-changes form two anonymous branches, but there is no branch marker to delete.
-Even if we had put a bookmark on `n3` and deleted it, `n3` would still be a
-visible head. To make that whole idea disappear from the visible history, we
-need to abandon all three of its changes.
-
-* `n1::n3` is inclusive, including both `n1` and `n3`.
-* `common..n3` excludes `common` and includes `n3`.
-
-We can first ask `jj` to show us what `n3` adds on top of `common`:
-
-```console
-$ jj log -r 'common..n3'
-○  n3
-○  n2
-○  n1
-~
-```
-
-The `..` operator excludes `common`: `common..n3` means "ancestors of `n3` that
-are not ancestors of `common`." In this simple graph, that gives us exactly the
-three changes on the branch we want to abandon. It also leaves `x1` and `x2`
-alone because neither is an ancestor of `n3`.
-
-There is another range operator that looks similar but answers a different
-question. `common::n3` means "changes on a path from `common` to `n3`,"
-including both ends. It selects `common`, `n1`, `n2`, and `n3`, so we must not
-abandon that range: the other branch still needs `common`.
-
-If we know the first change on the unwanted branch, `n1::n3` gives us the exact
-inclusive range from `n1` through `n3`. We can preview that range with `jj log`,
-then abandon it:
-
-```console
-$ jj log -r 'n1::n3'
-○  n3
-○  n2
-○  n1
-~
-$ jj abandon 'n1::n3'
-Abandoned 3 commits:
-  n3
-  n2
-  n1
-```
-
-If we know `common` but not `n1`, `common+::n3` selects the same range. The `+`
-means "direct children of `common`," so this starts after `common`; the `::n3`
-part then keeps only changes on a path to `n3`. If the branch merges history
-that is not descended from `common`, `common..n3` includes that history while
-`common+::n3` excludes it.
-
-The `x1` branch shows where that distinction ends. While it remains separate,
-both `common..n3` and `common+::n3` exclude `x1` because it is not an ancestor
-of `n3`. If `x1` were merged into `n3`, both ranges would include it. It would
-then be an ancestor of `n3` and on a path from a direct child of `common` to
-`n3`.
-`n1::n3` would still exclude `x1`, because `x1` is not a descendant of `n1`.
-If we want only the `n` branch after such a merge, `n1::n3` is the precise
-range to use.
-
-Abandoning only `n3` would not remove the branch. It would merely make `n2` the
-new anonymous head. The other boundary matters too. If an `n4` existed after
-`n3`, abandoning `n1::n3` would not abandon it. `jj` would rebase that surviving
-descendant onto `common` and report:
-
-```console
-Rebased 1 descendant commits onto parents of abandoned commits.
-```
-
-The `n4` change would remain as another anonymous head. If we want to discard an
-entire branch, we therefore need to use its actual first change and tip as the
-range boundaries. In our original graph, where `n3` really is the tip,
-abandoning the whole range leaves this visible graph:
-
-```text
-common ── x1 ── x2 (@)
-```
-
-This hides the commits; it does not immediately erase their objects. `jj`
-records the abandon in the
-[operation log](../fixing-problems/the-operation-log.md), whose earlier states
-keep the hidden commits in the repository. That repository-level history is why
-`jj undo` can restore the branch if abandoning it was a mistake. Once the old
-operations that refer to those commits are themselves abandoned, the commits
-can be removed by later garbage collection.
 
 Another really useful revset function is `trunk()`:
 
@@ -196,6 +105,104 @@ This will show the history from the working copy, some detail about remote
 branches, as well as the trunk. What's good varies between what you're trying
 to do and what your repository looks like, so experiment with some of this
 stuff to find something that works well for you.
+
+## Selecting a whole anonymous branch
+
+Let's put those operators to work on a real problem. In the last chapter, we
+made two anonymous branches from the same parent. Sooner or later, we'll make
+a branch we decide we don't want: suppose we tried one idea for three changes,
+started another idea from the same point, and then realized that the first
+idea was a dead end. Our history would look like this:
+
+```text
+common ─┬─ n1 ── n2 ── n3
+        ╰─ x1 ── x2 (@)
+```
+
+Here, `common`, `n1`, and the other labels stand for change IDs. The `n` and
+`x` changes form two anonymous branches, but of course, there's no branch
+marker to delete — that's the whole point of anonymous branches. Even if we
+had put a bookmark on `n3` and deleted it, `n3` would still be a visible head.
+If we want that whole first idea gone from our visible history, we need to
+abandon all three of its changes, and revsets let us name all three at once.
+
+Let's start by asking `jj` to show us what `n3` adds on top of `common`:
+
+```console
+$ jj log -r 'common..n3'
+○  n3
+○  n2
+○  n1
+~
+```
+
+The `..` operator excludes `common`: `common..n3` means "ancestors of `n3` that
+are not ancestors of `common`." In this simple graph, that gives us exactly the
+three changes on the branch we want to abandon. It also leaves `x1` and `x2`
+alone, because neither is an ancestor of `n3`.
+
+You may remember another range operator that looks similar. `common::n3` means
+"changes on a path from `common` to `n3`," including *both* ends. It selects
+`common`, `n1`, `n2`, and `n3` — so we must not abandon that range, because
+the other branch still needs `common`. This is the sort of off-by-one that's
+worth previewing with `jj log` before running anything destructive.
+
+If we know the first change on the unwanted branch, `n1::n3` gives us the
+exact inclusive range from `n1` through `n3`. Let's preview it, then abandon
+it:
+
+```console
+$ jj log -r 'n1::n3'
+○  n3
+○  n2
+○  n1
+~
+$ jj abandon 'n1::n3'
+Abandoned 3 commits:
+  n3
+  n2
+  n1
+```
+
+What if we know `common` but not `n1`? Then `common+::n3` selects the same
+range: the `+` means "direct children of `common`," so this starts just after
+`common`, and the `::n3` part keeps only changes on a path to `n3`. The two
+spellings can differ if the branch merges in history that isn't descended from
+`common` — `common..n3` would include that history, while `common+::n3`
+excludes it — but for a simple branch like ours, they're the same three
+changes.
+
+While our two branches stay separate, all of these ranges leave `x1` alone,
+because it isn't an ancestor of `n3`. If we had merged `x1` into `n3`, though,
+both `common..n3` and `common+::n3` would pick it up, since it would then be an
+ancestor of `n3`. `n1::n3` would still exclude it, because `x1` is not a
+descendant of `n1`. So when a branch has merges in it, `n1::n3` is the precise
+range to reach for.
+
+Both boundaries of the range matter. Abandoning only `n3` wouldn't remove the
+branch; it would just make `n2` the new anonymous head, and we'd be back where
+we started. And if an `n4` existed *after* `n3`, abandoning `n1::n3` wouldn't
+touch it — `jj` would rebase the survivor onto `common` and report:
+
+```console
+Rebased 1 descendant commits onto parents of abandoned commits.
+```
+
+So to discard an entire branch, we want its actual first change and its actual
+tip as the boundaries. In our graph, `n3` really is the tip, so abandoning the
+range leaves us with:
+
+```text
+common ── x1 ── x2 (@)
+```
+
+One reassuring note to close on: this hides the commits, it doesn't erase
+them. `jj` records the abandon in the
+[operation log](../fixing-problems/the-operation-log.md), whose earlier states
+keep the hidden commits around. That's why `jj undo` can bring the branch back
+if abandoning it was a mistake. Only once the old operations referring to
+those commits are themselves abandoned can garbage collection remove them for
+good.
 
 Revsets are very powerful, and you'll learn some useful ones as you explore
 more. At some point, we'll even talk about how to create custom aliases for

--- a/src/customization/configuring-jj.md
+++ b/src/customization/configuring-jj.md
@@ -1,17 +1,19 @@
 # Configuring `jj`
 
-Configuration lives in TOML files, and you get at them through `jj config`.
+`jj` stores its configuration in TOML files, and we can work with them through
+`jj config`. Let's start by seeing where they live.
 
 ## Where settings live
 
-There are four layers, and later ones win:
+There are four layers. Settings later in this list take precedence over earlier
+ones:
 
 1. built-in defaults
 2. your user config
 3. the repository's config
 4. `--config` on the command line
 
-Ask `jj` where the files are rather than guessing:
+We can ask `jj` where the files are rather than guessing:
 
 ```console
 $ jj config path --user
@@ -21,12 +23,12 @@ $ jj config path --repo
 /home/steve/.config/jj/repos/07d925992ceecfee7f5a/config.toml
 ```
 
-The repository config is worth a second look: it lives in *your* config
-directory, keyed by repository, not inside the repository itself. So it's
-per-repository but private to you — you can't accidentally commit it, and it
-won't turn up in anyone else's checkout.
+The repository config is worth a second look. It lives in *our* config
+directory, keyed by repository, rather than inside the repository itself. So we
+get per-repository settings that stay private to us. We can't accidentally
+commit them, and they won't turn up in anyone else's checkout.
 
-Three ways to change something. Set one key:
+There are three ways to change a setting. We can set one key:
 
 ```console
 $ jj config set --user ui.default-command log
@@ -38,8 +40,8 @@ Open the file in your editor:
 $ jj config edit --user
 ```
 
-Or override for a single command, which is the right tool for trying something
-out:
+Or we can override a setting for one command, which is handy when trying
+something out:
 
 ```console
 $ jj --config ui.graph.style=ascii log
@@ -49,7 +51,8 @@ $ jj --config ui.graph.style=ascii log
 |  upstream commit 2
 ```
 
-To see what's actually in effect, including everything you've never set:
+We can also ask what is currently in effect, including settings we've never
+changed ourselves:
 
 ```console
 $ jj config list                       # your settings
@@ -60,7 +63,7 @@ $ jj config get ui.editor
 `jj config unset --repo ui.default-command` removes a key and lets the layer
 underneath show through again.
 
-## Settings worth knowing about
+## Some useful settings
 
 ### What bare `jj` does
 
@@ -69,8 +72,8 @@ underneath show through again.
 default-command = "log"
 ```
 
-Out of the box, typing `jj` with no arguments prints the help. Most people set
-this to `log` or `status` within a week.
+Out of the box, typing `jj` with no arguments prints the help. I prefer to have
+it run `log` or `status` instead.
 
 ### Editors
 
@@ -82,9 +85,9 @@ merge-editor = "meld"  # resolving conflicts in jj resolve
 diff-formatter = ["difft", "--color=always", "$left", "$right"]
 ```
 
-Four different jobs, four different settings, because the right tool differs for
-each. The built-in TUI we've used for interactive splits is `:builtin`, and it's
-the default; `diff-editor` is how you swap in something else.
+These are four different jobs, so they have four different settings. The
+built-in TUI we've used for interactive splits is `:builtin`, and it's the
+default. We can change `diff-editor` if we prefer something else.
 
 ### Paging
 
@@ -105,7 +108,7 @@ edit = true
 ```
 
 Back in the edit workflow chapter we kept typing `jj next --edit`. Set this and
-`jj next` and `jj prev` edit by default; `--no-edit` gets the other behaviour
+`jj next` and `jj prev` edit by default; `--no-edit` gets the other behavior
 when you want it. If you've settled on the edit workflow, set it and stop
 typing the flag.
 
@@ -117,8 +120,9 @@ fetch = "origin"
 push = "origin"
 ```
 
-Which remote `jj git fetch` and `jj git push` use when you don't say. Useful on
-a fork, where you fetch from `upstream` and push to `origin`.
+These settings choose which remotes `jj git fetch` and `jj git push` use when we
+don't name one. They're especially useful on a fork, where we may fetch from
+`upstream` and push to `origin`.
 
 ### Keeping work off the remote
 
@@ -131,6 +135,36 @@ Any commit matching that revset — and anything descended from it — is refuse
 `jj git push`. A safety net for the "checkpoint" commits you make for yourself
 and never mean to publish. `jj git push` already refuses commits with no
 description and commits containing conflicts; this lets you add your own rule.
+
+### Signing your commits
+
+Some projects require every commit to be signed. `jj` does it for you, given a
+backend and a key:
+
+```toml
+[signing]
+behavior = "own"
+backend = "ssh"
+key = "~/.ssh/id_ed25519.pub"
+```
+
+`behavior` is the interesting setting. `own` signs commits we author whenever
+`jj` writes them, which is what we usually want. The default, `keep`, only
+re-signs our commits that were already signed before a rewrite. `force` signs
+every commit it writes, even when somebody else authored it, while `drop`
+removes a signature when a commit is rewritten. The backends are `ssh`, `gpg`,
+and `gpgsm`.
+
+`jj sign` signs a revision after the fact, and `jj unsign` removes one. To be
+sure nothing unsigned escapes:
+
+```toml
+[git]
+sign-on-push = true
+```
+
+Signatures aren't shown by default, since most of the time they're noise.
+`ui.show-cryptographic-signatures = true` puts them in the log.
 
 ### Stale workspaces
 
@@ -155,7 +189,7 @@ against a filesystem watcher, and needs the `watchman` binary on your `PATH`.
 
 ## Aliases
 
-Aliases save whole command lines:
+We can use aliases to save whole command lines:
 
 ```toml
 [aliases]
@@ -170,12 +204,12 @@ $ jj l
 ```
 
 The value is an array of arguments, not a string to be parsed by a shell.
-Anything you type after the alias is appended, so `jj l --limit 3` works.
+Anything we type after the alias is appended, so `jj l --limit 3` works.
 
 ## Revset aliases
 
-This is the more interesting kind. Revsets are a language, and you can add words
-to it:
+Revset aliases are a little more interesting. Revsets are a language, and we
+can add our own words to it:
 
 ```toml
 [revset-aliases]
@@ -186,14 +220,13 @@ to it:
 $ jj log -r 'mine()'
 ```
 
-Now `mine()` is available anywhere a revset is, including inside other aliases
-and other revset expressions. `trunk()` itself is one of these — `jj git clone`
-writes `revset-aliases."trunk()" = "main@origin"` into your repository config,
+Now `mine()` is available anywhere we can use a revset, including inside other
+aliases and revset expressions. `trunk()` itself is one of these. `jj git clone`
+writes `revset-aliases."trunk()" = "main@origin"` into our repository config,
 which is why the built-in defaults can refer to `trunk()` without knowing what
-your project calls its main branch.
+our project calls its main branch.
 
-The alias worth understanding is the one governing what you're allowed to
-rewrite:
+One alias worth understanding governs what we're allowed to rewrite:
 
 ```toml
 [revset-aliases]
@@ -234,5 +267,5 @@ l = ["log", "-r", "trunk()..@"]
 "mine()" = "trunk()..@"
 ```
 
-Small, but it removes several dozen keystrokes a day. Add to it when something
-irritates you twice.
+This is deliberately small, but it removes a bunch of repeated typing. I add to
+it when I notice myself reaching for the same option again and again.

--- a/src/customization/configuring-jj.md
+++ b/src/customization/configuring-jj.md
@@ -1,0 +1,238 @@
+# Configuring `jj`
+
+Configuration lives in TOML files, and you get at them through `jj config`.
+
+## Where settings live
+
+There are four layers, and later ones win:
+
+1. built-in defaults
+2. your user config
+3. the repository's config
+4. `--config` on the command line
+
+Ask `jj` where the files are rather than guessing:
+
+```console
+$ jj config path --user
+/home/steve/.config/jj/config.toml
+
+$ jj config path --repo
+/home/steve/.config/jj/repos/07d925992ceecfee7f5a/config.toml
+```
+
+The repository config is worth a second look: it lives in *your* config
+directory, keyed by repository, not inside the repository itself. So it's
+per-repository but private to you — you can't accidentally commit it, and it
+won't turn up in anyone else's checkout.
+
+Three ways to change something. Set one key:
+
+```console
+$ jj config set --user ui.default-command log
+```
+
+Open the file in your editor:
+
+```console
+$ jj config edit --user
+```
+
+Or override for a single command, which is the right tool for trying something
+out:
+
+```console
+$ jj --config ui.graph.style=ascii log
+@  oqtwrqnv steve@steveklabnik.com 2024-03-25 09:14:44 main* 07effb17
+|  (empty) local commit on main
++  quvlnmky steve@steveklabnik.com 2024-03-25 09:12:37 main@origin edd53bde
+|  upstream commit 2
+```
+
+To see what's actually in effect, including everything you've never set:
+
+```console
+$ jj config list                       # your settings
+$ jj config list --include-defaults    # and the built-in ones
+$ jj config get ui.editor
+```
+
+`jj config unset --repo ui.default-command` removes a key and lets the layer
+underneath show through again.
+
+## Settings worth knowing about
+
+### What bare `jj` does
+
+```toml
+[ui]
+default-command = "log"
+```
+
+Out of the box, typing `jj` with no arguments prints the help. Most people set
+this to `log` or `status` within a week.
+
+### Editors
+
+```toml
+[ui]
+editor = "nvim"  # writing commit descriptions
+diff-editor = ":builtin"  # picking hunks in jj split / jj squash -i
+merge-editor = "meld"  # resolving conflicts in jj resolve
+diff-formatter = ["difft", "--color=always", "$left", "$right"]
+```
+
+Four different jobs, four different settings, because the right tool differs for
+each. The built-in TUI we've used for interactive splits is `:builtin`, and it's
+the default; `diff-editor` is how you swap in something else.
+
+### Paging
+
+```toml
+[ui]
+pager = "less -FRX"
+paginate = "never"
+```
+
+`paginate = "never"` is the one to set when you're driving `jj` from a script,
+or anywhere a pager would hang waiting for a keypress nobody's there to make.
+
+### Movement
+
+```toml
+[ui.movement]
+edit = true
+```
+
+Back in the edit workflow chapter we kept typing `jj next --edit`. Set this and
+`jj next` and `jj prev` edit by default; `--no-edit` gets the other behaviour
+when you want it. If you've settled on the edit workflow, set it and stop
+typing the flag.
+
+### Remotes
+
+```toml
+[git]
+fetch = "origin"
+push = "origin"
+```
+
+Which remote `jj git fetch` and `jj git push` use when you don't say. Useful on
+a fork, where you fetch from `upstream` and push to `origin`.
+
+### Keeping work off the remote
+
+```toml
+[git]
+private-commits = "description(glob:'wip:*')"
+```
+
+Any commit matching that revset — and anything descended from it — is refused by
+`jj git push`. A safety net for the "checkpoint" commits you make for yourself
+and never mean to publish. `jj git push` already refuses commits with no
+description and commits containing conflicts; this lets you add your own rule.
+
+### Stale workspaces
+
+```toml
+[snapshot]
+auto-update-stale = true
+```
+
+From the workspaces chapter: apply `jj workspace update-stale` automatically
+instead of stopping to tell you about it.
+
+### Large repositories
+
+```toml
+[fsmonitor]
+backend = "watchman"
+```
+
+Snapshotting the working copy means checking every tracked file for changes.
+On a big repository that walk gets expensive. Watchman replaces it with a query
+against a filesystem watcher, and needs the `watchman` binary on your `PATH`.
+
+## Aliases
+
+Aliases save whole command lines:
+
+```toml
+[aliases]
+l = ["log", "-r", "trunk()..@"]
+```
+
+```console
+$ jj l
+@  oqtwrqnv steve@steveklabnik.com 2024-03-25 09:14:44 main* 07effb17
+│  (empty) local commit on main
+~
+```
+
+The value is an array of arguments, not a string to be parsed by a shell.
+Anything you type after the alias is appended, so `jj l --limit 3` works.
+
+## Revset aliases
+
+This is the more interesting kind. Revsets are a language, and you can add words
+to it:
+
+```toml
+[revset-aliases]
+"mine()" = "trunk()..@"
+```
+
+```console
+$ jj log -r 'mine()'
+```
+
+Now `mine()` is available anywhere a revset is, including inside other aliases
+and other revset expressions. `trunk()` itself is one of these — `jj git clone`
+writes `revset-aliases."trunk()" = "main@origin"` into your repository config,
+which is why the built-in defaults can refer to `trunk()` without knowing what
+your project calls its main branch.
+
+The alias worth understanding is the one governing what you're allowed to
+rewrite:
+
+```toml
+[revset-aliases]
+"immutable_heads()" = "builtin_immutable_heads() | remote_bookmarks()"
+```
+
+The built-in set is `trunk() | tags() | untracked_remote_bookmarks()`: trunk,
+tags, and remote bookmarks you don't track. Everything at or below those heads
+is frozen, which is why `jj log` draws them as `◆` and why `jj rebase` won't
+touch them. The line above widens it to every remote bookmark — nothing that has
+reached a remote can be rewritten. Some teams want that; if you use stacked PRs,
+you don't, because rewriting pushed branches is the entire workflow.
+
+Note the `builtin_immutable_heads() |` at the front. Assign to
+`immutable_heads()` without it and you *replace* the default set rather than
+adding to it, which unfreezes trunk. Always union with the builtin.
+
+## A starting point
+
+If you want something to paste and adjust:
+
+```toml
+[user]
+name = "Your Name"
+email = "you@example.com"
+
+[ui]
+default-command = "log"
+editor = "nvim"
+
+[ui.movement]
+edit = true
+
+[aliases]
+l = ["log", "-r", "trunk()..@"]
+
+[revset-aliases]
+"mine()" = "trunk()..@"
+```
+
+Small, but it removes several dozen keystrokes a day. Add to it when something
+irritates you twice.

--- a/src/customization/configuring-jj.md
+++ b/src/customization/configuring-jj.md
@@ -63,6 +63,12 @@ $ jj config get ui.editor
 `jj config unset --repo ui.default-command` removes a key and lets the layer
 underneath show through again.
 
+`--user`, `--repo`, and `--workspace` each name a whole layer. When a layer is
+spread across several files — a user config plus a `conf.d/` directory, say —
+`--user` writes to the first file `jj` loads. To pick one file exactly, give
+`--file <PATH>`; it works with `set`, `edit`, and `unset`, and points at any
+file `jj` reads.
+
 ## Some useful settings
 
 ### What bare `jj` does
@@ -236,8 +242,9 @@ One alias worth understanding governs what we're allowed to rewrite:
 "immutable_heads()" = "builtin_immutable_heads() | remote_bookmarks()"
 ```
 
-The built-in set is `trunk() | tags() | untracked_remote_bookmarks()`: trunk,
-tags, and remote bookmarks you don't track. Everything at or below those heads
+The built-in set is
+`trunk() | tags() | untracked_remote_bookmarks() | untracked_remote_tags()`:
+trunk, tags, and the remote bookmarks and tags you don't track. Everything at or below those heads
 is frozen, which is why `jj log` draws them as `◆` and why `jj rebase` won't
 touch them. The line above widens it to every remote bookmark — nothing that has
 reached a remote can be rewritten. Some teams want that; if you use stacked PRs,

--- a/src/customization/configuring-jj.md
+++ b/src/customization/configuring-jj.md
@@ -213,15 +213,18 @@ can add our own words to it:
 
 ```toml
 [revset-aliases]
-"mine()" = "trunk()..@"
+"stack()" = "trunk()..@"
 ```
 
 ```console
-$ jj log -r 'mine()'
+$ jj log -r 'stack()'
 ```
 
-Now `mine()` is available anywhere we can use a revset, including inside other
-aliases and revset expressions. `trunk()` itself is one of these. `jj git clone`
+Now `stack()` is available anywhere we can use a revset, including inside other
+aliases and revset expressions. One note on naming: `jj` will happily let an
+alias shadow a built-in function — remember `mine()` from the revsets chapter —
+and it won't warn you when it does, so pick names that aren't already taken.
+`trunk()` itself is one of these aliases. `jj git clone`
 writes `revset-aliases."trunk()" = "main@origin"` into our repository config,
 which is why the built-in defaults can refer to `trunk()` without knowing what
 our project calls its main branch.
@@ -264,7 +267,7 @@ edit = true
 l = ["log", "-r", "trunk()..@"]
 
 [revset-aliases]
-"mine()" = "trunk()..@"
+"stack()" = "trunk()..@"
 ```
 
 This is deliberately small, but it removes a bunch of repeated typing. I add to

--- a/src/customization/customizing-your-experience.md
+++ b/src/customization/customizing-your-experience.md
@@ -1,0 +1,11 @@
+# Customizing your experience
+
+`jj` ships with sensible defaults, and we've used it for this whole book without
+changing very many of them. A tool we use every day is still worth making our
+own, though. `jj` lets us customize which commands we run, what they show us,
+which sets of commits we can name, and which editors do the work.
+
+Here's what we're going to learn:
+
+* Configuring `jj`: where settings live, and the ones worth setting
+* Customizing the output of `jj` commands with templates

--- a/src/customization/templates.md
+++ b/src/customization/templates.md
@@ -44,4 +44,4 @@ Templates are powerful, and let you do a lot of interesting things. I would
 suggest reading [the documentation on templates][templates] to learn all of the
 details.
 
-[templates]: https://jj-vcs.github.io/jj/latest/templates/
+[templates]: https://docs.jj-vcs.dev/latest/templates/

--- a/src/customization/templates.md
+++ b/src/customization/templates.md
@@ -10,7 +10,7 @@ ourselves on what
 
 ```text
 $ jj log -r @-
-◉  yzlysuwt steve@steveklabnik.com 2024-02-29 00:35:12.000 -06:00 main f80a73c1
+○  yzlysuwt steve@steveklabnik.com 2024-02-29 00:35:12 main f80a73c1
 │  Fill out a table of contents
 ```
 
@@ -18,7 +18,7 @@ Let's give it a template instead:
 
 ```console
 $  jj log -r @- -T 'separate(" ", change_id, description.first_line())'
-◉  yzlysuwtylswszxknppsyqxqoktqpqpz Fill out a table of contents
+○  yzlysuwtylswszxknppsyqxqoktqpqpz Fill out a table of contents
 │
 ```
 
@@ -33,7 +33,7 @@ What if we wanted a nicer change ID? We can do that:
 
 ```console
 $  jj log -r @- -T 'separate(" ", change_id.shortest(8), description.first_line())'
-◉  yzlysuwt Fill out a table of contents
+○  yzlysuwt Fill out a table of contents
 │
 ```
 

--- a/src/fixing-problems/bisecting.md
+++ b/src/fixing-problems/bisecting.md
@@ -1,0 +1,75 @@
+# Finding the commit that broke it with `jj bisect`
+
+Everything else in this section has been about undoing something we did. This
+chapter is about finding out which past change caused a problem in the first
+place.
+
+The idea is the same as `git bisect`: we know something worked before and
+doesn't work now, so we can use a binary search to find where that changed.
+`jj bisect run` does the whole search for us, given a command that can tell a
+good revision from a bad one.
+
+Our command needs to exit `0` on a good revision and use most non-zero statuses
+for a bad one, which is the convention test runners already follow. There are
+two reserved statuses: `125` skips a revision that can't be tested, and `127`
+aborts the search. Let's put the command in a script somewhere *outside* the
+repository. `jj` will be checking out old revisions, so a script in the working
+copy could vanish along with everything else:
+
+```sh
+#!/bin/sh
+[ "$(cat v.txt)" -lt 4 ]
+```
+
+Then we can run it over the range we want to search:
+
+```console
+$ jj bisect run --range 'mutable() & ~empty()' -- ~/bin/check.sh
+Bisecting: 3 revisions left to test after this (roughly 2 steps)
+Now evaluating: upqnzxnm d8afdf06 c5
+Working copy  (@) now at: kzlyrqkk e7a2a494 (empty) (no description set)
+Parent commit (@-)      : upqnzxnm d8afdf06 c5
+The revision is bad.
+
+Bisecting: 1 revisions left to test after this (roughly 1 steps)
+Now evaluating: lrmywvmw 4e2d0df0 c4
+Working copy  (@) now at: oqonuxym d9edf35c (empty) (no description set)
+Parent commit (@-)      : lrmywvmw 4e2d0df0 c4
+The revision is bad.
+
+Search complete. To discard any revisions created during search, run:
+  jj op restore e31971608abc
+The first bad revision is: lrmywvmw 4e2d0df0 c4
+```
+
+At each step, `jj` checks out a revision, runs our command, and narrows the
+range. The answer at the end is the first revision where the command started
+failing.
+
+## The range
+
+`--range` is a revset, which gives us a lot of flexibility. `git bisect` asks us
+to mark one good commit and one bad commit and then walks between them. Here, we
+can describe the search space directly:
+
+* `mutable()` — everything `jj` permits you to rewrite. This can include pushed
+  commits on tracked remote bookmarks.
+* `trunk()..@` — the work on your branch.
+* `main@origin..main` — what you're about to push.
+
+Excluding empty commits with `& ~empty()` is often worth it, since testing a
+commit that changes nothing tells you nothing.
+
+## Cleaning up after it
+
+Notice what the output offers at the end:
+
+```text
+To discard any revisions created during search, run:
+  jj op restore e31971608abc
+```
+
+Bisecting checks out revisions as it searches, so it leaves working-copy
+commits behind. We can use the operation log from earlier in this section to
+clean them up. One command puts the repository back exactly as it was before
+the search, and `jj` gives us the operation ID rather than making us find it.

--- a/src/fixing-problems/divergent-changes.md
+++ b/src/fixing-problems/divergent-changes.md
@@ -171,6 +171,34 @@ both intact, both recoverable. The only real hazard is absent-mindedly
 continuing to work on top of the side you meant to throw away — which is why
 it's worth cleaning up promptly rather than living with the offsets.
 
+## When both sides have work: `jj converge`
+
+Here the old line was a duplicate we wanted gone, so `jj abandon` was the tool.
+The other case is two versions that each carry real, *different* work — two
+machines that both edited the same change, say — where you want to keep both
+sets of edits rather than throw one away. `jj` 0.45 added `jj converge` for
+that:
+
+```console
+$ jj converge -r 'divergent()'
+Found 1 divergent change(s) in the specified revset:
+- Change: znquvmmzlxqr with 2 commits:
+    znquvmmz/0 cfffda13 (divergent) add an evaluator
+    znquvmmz/1 6f590d66 feature | (divergent) add an evaluator
+
+Attempting to converge change znquvmmzlxqr...
+
+Successfully converged change: created commit 41e0c3d8b2ef.
+```
+
+It groups the divergent commits by change ID and tries to replace each group
+with a single commit, then rebases descendants and moves bookmarks to follow.
+The replacement is built from heuristics, and where they can't decide it prompts
+you — to merge two descriptions, to pick parents, and, rarely, to choose an
+author. `--no-interactive` prints a warning and stops instead, which is what a
+script wants. As always, `jj undo` reverses the whole thing if the result isn't
+what you hoped, and `jj op show -p` shows exactly what it did.
+
 The [official guide to divergent changes][divergence] covers a few rarer ways
 in and out, if you'd like more.
 

--- a/src/fixing-problems/divergent-changes.md
+++ b/src/fixing-problems/divergent-changes.md
@@ -1,0 +1,177 @@
+# Untangling divergent changes
+
+We've leaned hard on one promise throughout this book: a change ID names one
+change, and it survives every rewrite. There is a situation where that promise
+bends. It's called a *divergent change*, and it's worth meeting in a repository
+we don't care about before it happens in one we do, because the first time you
+see it, it looks alarming.
+
+Here's the short version: a change is divergent when *two visible commits*
+claim the same change ID. `jj` marks them `(divergent)` in the log, and refuses
+to let the bare change ID pick between them.
+
+## Making one on purpose
+
+Let's set up a little repository with a two-change stack and a bookmark on
+top:
+
+```console
+$ jj log
+@  znquvmmz steve@steveklabnik.com 2024-03-20 11:02:31 feature 6f590d66
+│  add an evaluator
+○  zluwzunl steve@steveklabnik.com 2024-03-20 11:02:14 511b69ca
+│  add a parser
+◆  zzzzzzzz root() 00000000
+```
+
+Now we'll amend the parser change — `jj edit zluwzunl`, fix a file, and come
+back up with `jj new znquvmmz`. We know what happens: both changes get new
+commit IDs, the evaluator gets rebased, and the old versions go into hiding.
+`jj evolog` can show them to us:
+
+```console
+$ jj evolog -r znquvmmz --no-graph
+znquvmmz steve@steveklabnik.com 2024-03-20 11:03:44 feature cfffda13
+add an evaluator
+-- operation 7a0508060358 snapshot working copy
+znquvmmz/1 steve@steveklabnik.com 2024-03-20 11:02:31 6f590d66 (hidden)
+add an evaluator
+-- operation a18d13686e71 describe commit 8c764b87308646d95ab0884ffb35e5d3ee20dbfd
+```
+
+So far, so normal. Now the mistake. A while later, we're rooting around in the
+evolog for something we lost, we find that old commit `6f590d66`, and — maybe
+thinking it's the current version — we point our bookmark at it:
+
+```console
+$ jj bookmark set feature -r 6f590d66 --allow-backwards
+Moved 1 bookmarks to znquvmmz/1 6f590d66 feature* | (divergent) add an evaluator
+```
+
+There's the word already. A bookmark keeps a commit visible, and so it keeps
+that commit's *ancestors* visible too. We've just resurrected the entire old
+version of the stack:
+
+```console
+$ jj log
+@  tkvuwxwx steve@steveklabnik.com 2024-03-20 11:03:44 c5324b95
+│  (empty) (no description set)
+○  znquvmmz/0 steve@steveklabnik.com 2024-03-20 11:03:44 cfffda13 (divergent)
+│  add an evaluator
+○  zluwzunl/0 steve@steveklabnik.com 2024-03-20 11:03:44 c2e9dfd1 (divergent)
+│  add a parser
+│ ○  znquvmmz/1 steve@steveklabnik.com 2024-03-20 11:02:31 feature 6f590d66 (divergent)
+│ │  add an evaluator
+│ ○  zluwzunl/1 steve@steveklabnik.com 2024-03-20 11:02:14 511b69ca (divergent)
+├─╯  add a parser
+◆  zzzzzzzz root() 00000000
+```
+
+Both versions of both changes, all four marked `(divergent)`. Note that a
+whole *stack* went divergent from one bookmark move. When people hit this in
+real life, it's rarely one commit — it's twenty, and it looks like the
+repository exploded. It didn't. It's the same two lines of history you can see
+right here, just longer.
+
+Moving a bookmark isn't the only way in. Fetching can do it too, if the remote
+has commits descended from a version you've since rewritten — a common one is
+someone (or CI) building on your branch right before you force-push over it.
+Two machines, or two workspaces, rewriting the same change also gets you here.
+However you arrive, the shape is the same: an old line and a new line, both
+visible.
+
+## Reading the display
+
+Those `/0` and `/1` suffixes are how `jj` names the versions of a change.
+You've seen them in `jj evolog` output already, counting back through hidden
+predecessors. Now that two versions are *visible*, the suffixes are how we
+tell them apart, and the bare change ID stops working:
+
+```console
+$ jj show znquvmmz
+Error: Change ID `znquvmmz` is divergent
+Hint: Use change offset to select single revision: znquvmmz/0, znquvmmz/1
+Hint: Use `change_id(znquvmmz)` to select all revisions
+Hint: To abandon unneeded revisions, run `jj abandon <commit_id>`
+```
+
+This error is usually the moment people discover divergence exists, so it's
+nice that the hints tell you everything: pick a side with an offset, or take
+all sides with `change_id()`.
+
+One caution about the offsets: they're assigned by sorting the visible
+commits, and they get *reassigned* as commits appear and disappear. For
+looking around, `znquvmmz/1` is fine. For a multi-step cleanup, use commit
+IDs — `6f590d66` means the same commit tomorrow, and `/1` may not.
+
+`jj log -r 'divergent()'` shows every divergent commit in the repository,
+which is the quickest way to see the full extent of the problem.
+
+## Cleaning it up
+
+Our repository has a new line we want and an old line we don't. The plan: make
+sure nothing we care about is attached to the old line, then abandon the old
+line, all of it.
+
+First, the bookmark. It's sitting on the old tip, which is both why the old
+line is visible and not where we want it. Let's put it back on the current
+version:
+
+```console
+$ jj bookmark set feature -r cfffda13 --allow-backwards
+Moved 1 bookmarks to znquvmmz/0 cfffda13 feature* | (divergent) add an evaluator
+```
+
+Now let's check the old line is really abandoned-safe: no bookmarks left on
+it, and nothing built on top of its tip. We use commit IDs for the range,
+since the change IDs are exactly what's ambiguous right now:
+
+```console
+$ jj log -r '511b69ca::6f590d66 & (bookmarks() | remote_bookmarks())'
+$ jj log -r 'children(6f590d66)'
+```
+
+Both empty. If they weren't — if a bookmark or some new work were attached to
+the old line — we'd stop here and move or rebase those first.
+
+Now we can abandon the old line. This is the same inclusive-range trick from
+the revsets chapter, from the old line's first commit through its tip:
+
+```console
+$ jj abandon '511b69ca::6f590d66'
+Abandoned 2 commits:
+  znquvmmz/1 6f590d66 (divergent) add an evaluator
+  zluwzunl/1 511b69ca (divergent) add a parser
+```
+
+The range matters. If we'd abandoned only the tip, `511b69ca` would have become
+the old line's new head — still visible, still divergent, and we'd be playing
+whack-a-mole down the whole stack. Abandon the line, not the commit.
+
+And we're back to normal:
+
+```console
+$ jj log -r 'divergent()'
+$ jj log
+@  tkvuwxwx steve@steveklabnik.com 2024-03-20 11:03:44 c5324b95
+│  (empty) (no description set)
+○  znquvmmz steve@steveklabnik.com 2024-03-20 11:03:44 feature cfffda13
+│  add an evaluator
+○  zluwzunl steve@steveklabnik.com 2024-03-20 11:03:44 c2e9dfd1
+│  add a parser
+◆  zzzzzzzz root() 00000000
+```
+
+No offsets, no `(divergent)`, one version of each change.
+
+Two more things worth knowing. If the operation that caused the divergence was
+the *last* thing you did, `jj undo` fixes it in one step, as usual. And
+nothing here was ever dangerous: a divergent change is two visible commits,
+both intact, both recoverable. The only real hazard is absent-mindedly
+continuing to work on top of the side you meant to throw away — which is why
+it's worth cleaning up promptly rather than living with the offsets.
+
+The [official guide to divergent changes][divergence] covers a few rarer ways
+in and out, if you'd like more.
+
+[divergence]: https://docs.jj-vcs.dev/latest/guides/divergence/

--- a/src/fixing-problems/intro.md
+++ b/src/fixing-problems/intro.md
@@ -1,0 +1,25 @@
+# Fixing Problems
+
+At some point you're going to make a mess. You'll abandon the wrong change,
+squash something into the wrong parent, or resolve a conflict in a way you
+regret twenty minutes later.
+
+If you've used `git` for a while, you know the drill: you go and look up
+`git reflog`, you find a hash that looks about right, and you hope. It works,
+mostly, and it feels like surgery.
+
+`jj` takes this seriously enough that it's not a recovery tool bolted on the
+side; it's how the whole thing works. Every command you run is recorded, the
+old state is kept, and going back is a normal thing to do rather than an
+emergency.
+
+Here's what we're going to learn:
+
+* Undoing your last command with `jj undo`
+* Reading the history of your repository's *states* with `jj op log`, and
+  jumping back to one
+* Watching a single change evolve over time with `jj evolog`
+* Throwing away changes on purpose, with `jj restore` and `jj revert`
+
+You've already used `jj undo` a couple of times in this book, on the promise
+that I'd explain it later. It's later.

--- a/src/fixing-problems/intro.md
+++ b/src/fixing-problems/intro.md
@@ -18,6 +18,8 @@ Here's what we're going to learn:
 * Reading the history of your repository's *states* with `jj op log`, and
   jumping back to one
 * Watching a single change evolve over time with `jj evolog`
+* Recognizing and untangling *divergent changes*, where two visible commits
+  claim the same change ID
 * Throwing away changes on purpose, with `jj restore` and `jj revert`
 * Hunting down the change that broke something, with `jj bisect`
 

--- a/src/fixing-problems/intro.md
+++ b/src/fixing-problems/intro.md
@@ -1,17 +1,16 @@
 # Fixing Problems
 
-At some point you're going to make a mess. You'll abandon the wrong change,
-squash something into the wrong parent, or resolve a conflict in a way you
-regret twenty minutes later.
+At some point, we're going to make a mistake. We may abandon the wrong change,
+squash something into the wrong parent, or resolve a conflict and then realize
+we preferred the other version.
 
-If you've used `git` for a while, you know the drill: you go and look up
-`git reflog`, you find a hash that looks about right, and you hope. It works,
-mostly, and it feels like surgery.
+If you've used `git` for a while, you may have reached for `git reflog`, found a
+hash that looked about right, and tried to put things back together. This often
+works, but it can feel a bit like emergency recovery.
 
-`jj` takes this seriously enough that it's not a recovery tool bolted on the
-side; it's how the whole thing works. Every command you run is recorded, the
-old state is kept, and going back is a normal thing to do rather than an
-emergency.
+Recovery works differently in `jj`. Every command we run is recorded, the old
+state is kept, and going back is a normal part of the tool rather than a
+separate emergency procedure.
 
 Here's what we're going to learn:
 
@@ -20,6 +19,7 @@ Here's what we're going to learn:
   jumping back to one
 * Watching a single change evolve over time with `jj evolog`
 * Throwing away changes on purpose, with `jj restore` and `jj revert`
+* Hunting down the change that broke something, with `jj bisect`
 
 You've already used `jj undo` a couple of times in this book, on the promise
 that I'd explain it later. It's later.

--- a/src/fixing-problems/reverting-changes.md
+++ b/src/fixing-problems/reverting-changes.md
@@ -1,0 +1,85 @@
+# Throwing work away on purpose
+
+Everything so far has been about getting work back. Sometimes we decide that
+some work should stay out of the project instead. `jj` has a few different
+tools for that, depending on exactly what we want to remove.
+
+## Discarding edits in the working copy
+
+Let's say we've been working on something, it hasn't worked out, and we want the
+files back the way they were. That's what `jj restore` does:
+
+```console
+$ jj st
+Working copy changes:
+M f.txt
+Working copy  (@) : wtylzslq 4528b111 next
+Parent commit (@-): usvzmupx c39e9f3f add a better feature
+$ jj restore
+Working copy  (@) now at: wtylzslq 4f4e99e0 (empty) next
+Parent commit (@-)      : usvzmupx c39e9f3f add a better feature
+Added 0 files, modified 1 files, removed 0 files
+```
+
+Our change is empty again. This is the rough equivalent of `git restore` or the
+old `git checkout -- .`, and by default it restores everything in `@` from its
+parent. Name paths if you only want some of them back, or use `--from` to pull
+the contents from somewhere other than the parent.
+
+Nothing is really lost here either, of course — the pre-restore state is an
+operation, so `jj undo` brings your edits back.
+
+## Getting rid of a whole change
+
+We've been using `jj abandon` throughout the book for this. It makes the change
+go away and rebases anything that was sitting on top of it:
+
+```console
+$ jj abandon mlzwmxzs
+Abandoned 1 commits:
+  mlzwmxzs 9a4ad229 (empty) (no description set)
+```
+
+Use it for work you never want to see again — a scratch change, a dead end, an
+empty commit you accidentally created.
+
+## Undoing a change that's already shared
+
+`jj abandon` rewrites history: the change simply stops existing. That's fine
+while the work is ours, but it can cause problems after other people have
+pulled it.
+Pushing alone doesn't necessarily make a commit immutable: commits published
+through tracked feature bookmarks remain mutable by default. Don't rely on the
+immutability guard to decide whether a rewrite is safe to share.
+
+Instead, we want a *new* commit that undoes the old one. We can make one with
+`jj revert`:
+
+```console
+$ jj revert -r usvzmupx -o @
+Reverted 1 commits as follows:
+  uykkwoyr 1ce4fe35 Revert "add a better feature"
+```
+
+```console
+$ jj log --limit 3
+○  uykkwoyr steve@steveklabnik.com 2024-03-20 10:04:14 1ce4fe35
+│  Revert "add a better feature"
+@  wtylzslq steve@steveklabnik.com 2024-03-20 10:04:14 4f4e99e0
+│  (empty) next
+○  usvzmupx steve@steveklabnik.com 2024-03-20 10:02:11 c39e9f3f
+│  add a better feature
+```
+
+`add a better feature` is still there, untouched, and there's now a commit after
+it that applies its diff backwards. History is intact and the effect is gone,
+which is what you want on a shared branch. `-r` says what to revert and `-o`
+says where to put the result, the same way `-o` works for `jj rebase`.
+
+## Which one do I want?
+
+* If the files in `@` are wrong, use `jj restore`.
+* If a whole change is unwanted and still local, use `jj abandon`.
+* If a whole change is unwanted and already pushed, use `jj revert`.
+
+If we pick the wrong one, `jj undo` gives us a way back.

--- a/src/fixing-problems/the-evolog.md
+++ b/src/fixing-problems/the-evolog.md
@@ -49,6 +49,68 @@ If we pass `-p`, we get the diff at each step. This is the version I usually
 reach for, because it shows us what the change *contained* over time, not just
 what it was called.
 
+## When two versions stay visible
+
+Normally, only the newest entry in an evolog is visible. There is one awkward
+case worth recognizing: we can rewrite a stack, move its bookmark to the new
+tip, and still see both versions of its changes in `jj log`. They are marked
+`(divergent)` because each change ID now names two visible commit IDs.
+
+This can be surprising when the bookmark looks right. In a repository where I
+ran into this, the local bookmark, its Git copy, and the tracked remote bookmark
+all pointed at the new commit:
+
+```console
+$ jj bookmark list --all
+new-chapters: ynossmku 0854177d clarify repository mode defaults
+  @git: ynossmku 0854177d clarify repository mode defaults
+  @origin: ynossmku 0854177d clarify repository mode defaults
+```
+
+The old stack was still an anonymous visible head. Moving and pushing a
+bookmark selects the new line, but it does not abandon another visible head.
+We can see both versions without guessing from the graph:
+
+```console
+$ jj log -r 'heads(divergent())' --no-graph \
+    -T 'change_id.short() ++ " " ++ commit_id.short() ++ "\n"'
+vxmynnlnrlzt 0c71df124215
+vxmynnlnrlzt 11ff48792102
+```
+
+Here `0c71df124215` is on the line retained by `new-chapters`, while
+`11ff48792102` is the tip of the old line. The repeated change ID tells us that
+these are divergent versions of the same logical change. `jj log -r
+'divergent()'` shows every affected version, and `jj log -r 'heads(all())'`
+helps us spot unbookmarked heads.
+
+Before throwing the old line away, let's check that no bookmark points into it
+and that nothing descends from its tip. We use commit IDs throughout, because
+the change IDs are precisely what is ambiguous here:
+
+```console
+$ jj log -r \
+    'd5487b35a605::11ff48792102 & (bookmarks() | remote_bookmarks())'
+$ jj log -r 'children(11ff48792102)'
+```
+
+Both commands produced no commits in this case. We can now abandon the whole
+old range, from its first divergent commit through its tip:
+
+```console
+$ jj abandon 'd5487b35a605::11ff48792102'
+Abandoned 27 commits:
+  vxmynnln/19 11ff4879 (divergent) note jj change ID stability across plain git clones
+  ...
+$ jj log -r 'divergent()'
+```
+
+That last log is empty. Abandoning only `11ff48792102` would not have finished
+the job: its parent would become the old line's next anonymous head, leaving the
+other 26 changes divergent. If the checks find a bookmark or descendants, we
+should stop and decide whether to move or rebase them before abandoning
+anything.
+
 ## evolog versus op log
 
 These two commands can be easy to confuse, so let's put the distinction in one

--- a/src/fixing-problems/the-evolog.md
+++ b/src/fixing-problems/the-evolog.md
@@ -51,131 +51,16 @@ what it was called.
 
 ## When two versions stay visible
 
-Normally, only the newest entry in an evolog is visible. There is one awkward
-case worth recognizing: we can end up with both versions of a rewritten stack
-in `jj log`. They are marked `(divergent)` because each change ID now names two
-visible commit IDs.
+Normally, only the newest entry in an evolog is visible; everything older is
+`(hidden)`. But hidden commits can come back. Put a bookmark on one, build a
+new commit on top of one, or fetch history that descends from one, and it
+becomes visible again — alongside its newer self. At that point a single
+change ID names two visible commits, and `jj` marks both `(divergent)`.
 
-The rewrite alone does not cause this. Normally it creates a successor for
-each commit, keeps the change IDs, and hides the predecessors. A hidden commit
-can become visible again, though, if we put a bookmark on it, edit it, make it
-a working copy, or add a visible descendant. The [Jujutsu guide to divergent
-changes][divergence] calls out each of these cases, as well as two processes
-rewriting the same change at the same time.
-
-We can reconstruct what happened in this repository from the operation log.
-After the rewrite, the old `new-chapters@origin` and `pdf-print@origin` targets
-were both marked `(hidden)`, and `jj log -r 'divergent()'` was empty. A later
-operation accidentally moved `pdf-print` back to the old commit `37b65b73`:
-
-```console
-$ jj op log --no-graph
-7152344d1e5b you@example.com default@ 2026-08-22 15:29:06, lasted 7 milliseconds
-point bookmark pdf-print to commit 37b65b734abcd1e2f3a4b5c6d7e8f9a0b1c2d3e4
-args: jj bookmark set pdf-print -r 37b65b73
-58d5d578ddfc you@example.com default@ 2026-08-22 15:28:58, lasted 9 milliseconds
-new empty commit
-args: jj new
-9889fa7911c5 you@example.com default@ 2026-08-22 15:28:51, lasted 12 milliseconds
-snapshot working copy
-args: jj new
-```
-
-Putting the bookmark there made that commit and all its ancestors visible.
-Those ancestors were the predecessor versions of the rewritten stack, so we
-now had two visible commit IDs for each of 28 change IDs. This is why a whole
-series appeared divergent at once. It was a consequence of that accidental
-bookmark move, not something that every rewrite produces. Another way to get
-the same result would be to fetch a new commit whose history descends from one
-of our hidden predecessors.
-
-This can be surprising when the bookmark looks right. In a repository where I
-ran into this, the local bookmark, its Git copy, and the tracked remote bookmark
-all pointed at the new commit:
-
-```console
-$ jj bookmark list --all
-new-chapters: ynossmku 0854177d clarify repository mode defaults
-  @git: ynossmku 0854177d clarify repository mode defaults
-  @origin: ynossmku 0854177d clarify repository mode defaults
-```
-
-The old stack was still an anonymous visible head. Moving and pushing a
-bookmark selects the new line, but it does not abandon another visible head.
-We can see both versions without guessing from the graph:
-
-```console
-$ jj log -r 'heads(divergent())' --no-graph
-vxmynnln/0 you@example.com 2026-08-22 15:28:51 0c71df12 (divergent)
-explain change ID stability across clones
-vxmynnln/19 you@example.com 2026-08-22 15:07:55 11ff4879 (divergent)
-note jj change ID stability across plain git clones
-```
-
-Here `0c71df124215` is on the line retained by `new-chapters`, while
-`11ff48792102` is the tip of the old line. The repeated change ID tells us that
-these are divergent versions of the same logical change. These are the two
-tips. We can find their last shared commit with `fork_point()`.
-
-`fork_point()` is shorthand for intersecting the two sets of ancestors and
-selecting their heads: `heads(::0c71df124215 & ::11ff48792102)`.
-
-Let's see:
-
-```console
-$ jj log -r 'fork_point(0c71df124215 | 11ff48792102)' --no-graph
-ppxpvmnv you@example.com 2026-08-20 16:31:00 update-for-jj-0.44 8827278a
-docs: correct conflict graph glyphs
-```
-
-Here `8827278aa4c9` is the nearest ancestor shared by both tips. If we want to
-see the first commit on each side of the split as well, we can remove that
-commit and its ancestors from the two histories, then ask for the roots of
-what remains:
-
-```console
-$ jj log -r \
-    'roots(8827278aa4c9..(0c71df124215 | 11ff48792102))' \
-    --no-graph
-orqqvtqp/0 you@example.com 2026-08-22 15:25:02 0bf91872 (divergent)
-explain commit shorthand and push dry runs
-orqqvtqp/1 you@example.com 2026-08-20 16:34:40 d5487b35 (divergent)
-docs: document commit shorthand and push dry runs
-```
-
-The repeated `orqqvtqp` change ID shows us exactly where the two series
-separated: these are the first two visible versions after their shared parent.
-`jj log -r 'divergent()'` shows every affected version, and `jj log -r
-'heads(all())'` helps us spot unbookmarked heads.
-
-Before throwing the old line away, let's check that no bookmark points into it
-and that nothing descends from its tip. We use commit IDs throughout, because
-the change IDs are precisely what is ambiguous here:
-
-```console
-$ jj log -r \
-    'd5487b35a605::11ff48792102 & (bookmarks() | remote_bookmarks())'
-$ jj log -r 'children(11ff48792102)'
-```
-
-Both commands produced no commits in this case. We can now abandon the whole
-old range, from its first divergent commit through its tip:
-
-```console
-$ jj abandon 'd5487b35a605::11ff48792102'
-Abandoned 27 commits:
-  vxmynnln/19 11ff4879 (divergent) note jj change ID stability across plain git clones
-  ...
-$ jj log -r 'divergent()'
-```
-
-That last log is empty. Abandoning only `11ff48792102` would not have finished
-the job: its parent would become the old line's next anonymous head, leaving the
-other 26 changes divergent. If the checks find a bookmark or descendants, we
-should stop and decide whether to move or rebase them before abandoning
-anything.
-
-[divergence]: https://docs.jj-vcs.dev/latest/guides/divergence/
+That situation deserves a proper walkthrough of its own, and it gets one in
+[the next chapter](divergent-changes.md). For now, just file away the
+connection: the old versions the evolog shows you are real commits, and
+"divergent" is what it's called when one of them escapes.
 
 ## evolog versus op log
 

--- a/src/fixing-problems/the-evolog.md
+++ b/src/fixing-problems/the-evolog.md
@@ -1,0 +1,70 @@
+# Watching a change evolve with `jj evolog`
+
+We've said a few times now that a change ID is stable while the commit ID
+underneath it changes. Every time you describe a change, edit its files, squash
+something into it, or let it get automatically rebased, you get a new commit ID
+and the same change ID.
+
+`jj evolog` shows you that history. Here's a change that's been through a few
+rounds:
+
+```console
+$ jj evolog -r usvzmupx
+○  usvzmupx steve@steveklabnik.com 2024-03-20 10:02:11 c39e9f3f
+│  add a better feature
+│  -- operation c4e5378aa59c snapshot working copy
+○  usvzmupx/1 steve@steveklabnik.com 2024-03-20 10:01:58 0ea8e5fc (hidden)
+│  add a better feature
+│  -- operation 3286efef174e describe commit e7b530dc15e0
+○  usvzmupx/2 steve@steveklabnik.com 2024-03-20 10:01:58 e7b530dc (hidden)
+│  add a feature
+│  -- operation 685d3932d80a snapshot working copy
+○  usvzmupx/3 steve@steveklabnik.com 2024-03-20 10:01:40 6d256008 (hidden)
+│  add a feature
+│  -- operation 91adfe1a92ae describe commit 39f08e04f359
+○  usvzmupx/4 steve@steveklabnik.com 2024-03-20 10:01:40 39f08e04 (hidden)
+│  (no description set)
+│  -- operation cbf76d26122b snapshot working copy
+○  usvzmupx/5 steve@steveklabnik.com 2024-03-20 10:01:22 6161a9a2 (hidden)
+   (empty) (no description set)
+   -- operation 4261b1b2ee68 add workspace 'default'
+```
+
+If we read it from bottom to top, we can watch the change evolve. It starts as
+the empty commit `jj git init` made. It gets some content. It gets described as
+"add a feature". More content. Then a better description. Every one of those
+steps left a commit behind, and they're all still here.
+
+That `usvzmupx/1` notation is how `jj` refers to older versions of a change: the
+change ID, then which step back you mean. And `(hidden)` means what it did in
+`jj op show` — the commit exists, it's just not part of the visible history any
+more.
+
+Each entry also names the operation that produced it, on the `-- operation`
+line, which is the bridge back to the last chapter. If you spot the version you
+want here, you can find the operation that came after it and `jj op restore` to
+just before the step you regret.
+
+If we pass `-p`, we get the diff at each step. This is the version I usually
+reach for, because it shows us what the change *contained* over time, not just
+what it was called.
+
+## evolog versus op log
+
+These two commands can be easy to confuse, so let's put the distinction in one
+line each.
+
+`jj op log` is a history of your **repository**: what you did, in order, to
+everything.
+
+`jj evolog` is a history of one **change**: every version that one logical piece
+of work has ever had.
+
+They're two different views of the same data. When we know something went wrong
+but not which change it affected, we can use `jj op log`. When we know which
+change went wrong but not when, we can use `jj evolog`.
+
+One last note: `jj evolog` used to be called `jj obslog`, for "obsolete log".
+That name still works if you type it, and you'll see it in older blog posts and
+Discord messages, but `evolog` — for "evolution" — is what it's called now, and
+it's a much better description of what you're looking at.

--- a/src/fixing-problems/the-evolog.md
+++ b/src/fixing-problems/the-evolog.md
@@ -52,9 +52,42 @@ what it was called.
 ## When two versions stay visible
 
 Normally, only the newest entry in an evolog is visible. There is one awkward
-case worth recognizing: we can rewrite a stack, move its bookmark to the new
-tip, and still see both versions of its changes in `jj log`. They are marked
-`(divergent)` because each change ID now names two visible commit IDs.
+case worth recognizing: we can end up with both versions of a rewritten stack
+in `jj log`. They are marked `(divergent)` because each change ID now names two
+visible commit IDs.
+
+The rewrite alone does not cause this. Normally it creates a successor for
+each commit, keeps the change IDs, and hides the predecessors. A hidden commit
+can become visible again, though, if we put a bookmark on it, edit it, make it
+a working copy, or add a visible descendant. The [Jujutsu guide to divergent
+changes][divergence] calls out each of these cases, as well as two processes
+rewriting the same change at the same time.
+
+We can reconstruct what happened in this repository from the operation log.
+After the rewrite, the old `new-chapters@origin` and `pdf-print@origin` targets
+were both marked `(hidden)`, and `jj log -r 'divergent()'` was empty. A later
+operation accidentally moved `pdf-print` back to the old commit `37b65b73`:
+
+```console
+$ jj op log --no-graph
+7152344d1e5b you@example.com default@ 2026-08-22 15:29:06, lasted 7 milliseconds
+point bookmark pdf-print to commit 37b65b734abcd1e2f3a4b5c6d7e8f9a0b1c2d3e4
+args: jj bookmark set pdf-print -r 37b65b73
+58d5d578ddfc you@example.com default@ 2026-08-22 15:28:58, lasted 9 milliseconds
+new empty commit
+args: jj new
+9889fa7911c5 you@example.com default@ 2026-08-22 15:28:51, lasted 12 milliseconds
+snapshot working copy
+args: jj new
+```
+
+Putting the bookmark there made that commit and all its ancestors visible.
+Those ancestors were the predecessor versions of the rewritten stack, so we
+now had two visible commit IDs for each of 28 change IDs. This is why a whole
+series appeared divergent at once. It was a consequence of that accidental
+bookmark move, not something that every rewrite produces. Another way to get
+the same result would be to fetch a new commit whose history descends from one
+of our hidden predecessors.
 
 This can be surprising when the bookmark looks right. In a repository where I
 ran into this, the local bookmark, its Git copy, and the tracked remote bookmark
@@ -72,17 +105,48 @@ bookmark selects the new line, but it does not abandon another visible head.
 We can see both versions without guessing from the graph:
 
 ```console
-$ jj log -r 'heads(divergent())' --no-graph \
-    -T 'change_id.short() ++ " " ++ commit_id.short() ++ "\n"'
-vxmynnlnrlzt 0c71df124215
-vxmynnlnrlzt 11ff48792102
+$ jj log -r 'heads(divergent())' --no-graph
+vxmynnln/0 you@example.com 2026-08-22 15:28:51 0c71df12 (divergent)
+explain change ID stability across clones
+vxmynnln/19 you@example.com 2026-08-22 15:07:55 11ff4879 (divergent)
+note jj change ID stability across plain git clones
 ```
 
 Here `0c71df124215` is on the line retained by `new-chapters`, while
 `11ff48792102` is the tip of the old line. The repeated change ID tells us that
-these are divergent versions of the same logical change. `jj log -r
-'divergent()'` shows every affected version, and `jj log -r 'heads(all())'`
-helps us spot unbookmarked heads.
+these are divergent versions of the same logical change. These are the two
+tips. We can find their last shared commit with `fork_point()`.
+
+`fork_point()` is shorthand for intersecting the two sets of ancestors and
+selecting their heads: `heads(::0c71df124215 & ::11ff48792102)`.
+
+Let's see:
+
+```console
+$ jj log -r 'fork_point(0c71df124215 | 11ff48792102)' --no-graph
+ppxpvmnv you@example.com 2026-08-20 16:31:00 update-for-jj-0.44 8827278a
+docs: correct conflict graph glyphs
+```
+
+Here `8827278aa4c9` is the nearest ancestor shared by both tips. If we want to
+see the first commit on each side of the split as well, we can remove that
+commit and its ancestors from the two histories, then ask for the roots of
+what remains:
+
+```console
+$ jj log -r \
+    'roots(8827278aa4c9..(0c71df124215 | 11ff48792102))' \
+    --no-graph
+orqqvtqp/0 you@example.com 2026-08-22 15:25:02 0bf91872 (divergent)
+explain commit shorthand and push dry runs
+orqqvtqp/1 you@example.com 2026-08-20 16:34:40 d5487b35 (divergent)
+docs: document commit shorthand and push dry runs
+```
+
+The repeated `orqqvtqp` change ID shows us exactly where the two series
+separated: these are the first two visible versions after their shared parent.
+`jj log -r 'divergent()'` shows every affected version, and `jj log -r
+'heads(all())'` helps us spot unbookmarked heads.
 
 Before throwing the old line away, let's check that no bookmark points into it
 and that nothing descends from its tip. We use commit IDs throughout, because
@@ -110,6 +174,8 @@ the job: its parent would become the old line's next anonymous head, leaving the
 other 26 changes divergent. If the checks find a bookmark or descendants, we
 should stop and decide whether to move or rebase them before abandoning
 anything.
+
+[divergence]: https://docs.jj-vcs.dev/latest/guides/divergence/
 
 ## evolog versus op log
 

--- a/src/fixing-problems/the-operation-log.md
+++ b/src/fixing-problems/the-operation-log.md
@@ -1,0 +1,154 @@
+# The operation log
+
+We now know that every repository change `jj` makes is recorded as an
+operation. A single command can create more than one operation, while a
+read-only command creates none. Let's look at that record with `jj op log`:
+
+```console
+$ jj op log
+@  4079800aed31 steve@steves-laptop default@ now, lasted 12 milliseconds
+│  snapshot working copy
+│  args: jj op log
+○  1775539db729 steve@steves-laptop default@ now, lasted 12 milliseconds
+│  new empty commit
+│  args: jj new -m 'add goodbye'
+○  ecbf2e1106cf steve@steves-laptop default@ now, lasted 11 milliseconds
+│  snapshot working copy
+│  args: jj new -m 'add goodbye'
+○  cac23ddcd31f steve@steves-laptop default@ now, lasted 12 milliseconds
+│  new empty commit
+│  args: jj new -m 'add a comment'
+○  58e635d3bf7d steve@steves-laptop default@ now, lasted 10 milliseconds
+│  describe commit 0439edc8c87e
+│  args: jj describe -m 'hello world'
+○  eab1b981cdcd steve@steves-laptop default@ now, lasted 11 milliseconds
+│  snapshot working copy
+│  args: jj describe -m 'hello world'
+○  194587de219c steve@steves-laptop now, lasted 18 milliseconds
+│  add workspace 'default'
+○  000000000000 root()
+```
+
+This looks a bit like `jj log`, and that's on purpose, but don't confuse the
+two. `jj log` shows you commits. `jj op log` shows you *states of the whole
+repository*. Each of those IDs on the left names one complete snapshot of
+everything: every commit, every bookmark, where `@` was pointing, the lot.
+
+A few things to notice.
+
+Each entry records the command that caused it, on the `args:` line. That's often
+enough on its own to work out where things went wrong.
+
+There are more entries than commands you ran. `jj new -m 'add goodbye'` produced
+two: a "snapshot working copy" and then a "new empty commit". Remember from way
+back in the `jj st` chapter that `jj` snapshots your working copy before doing
+anything else. That snapshot is an operation like any other, which is why you
+can undo your way back to a state you never explicitly committed.
+
+Right at the bottom is `add workspace 'default'` — that's `jj git init` — and
+below that, an operation root, in the same spirit as the commit root.
+
+The name and hostname come from your OS account, not from the `user.name` and
+`user.email` you set for commits. They're separate settings, `operation.username`
+and `operation.hostname`, so anonymizing your commit identity doesn't anonymize
+this. This is worth knowing if you care about that sort of thing.
+
+## Going back to an old state
+
+Say we've had a bad afternoon:
+
+```console
+$ jj log
+@  toumkvst steve@steveklabnik.com 2024-03-20 09:14:40 bc36132e
+│  (empty) even more mess
+○  ozylkotm steve@steveklabnik.com 2024-03-20 09:14:40 215023b0
+│  a description I regret
+○  zzzzmznr steve@steveklabnik.com 2024-03-20 09:14:20 3e44726c
+│  hello world
+◆  zzzzzzzz root() 00000000
+```
+
+We abandoned a change we wanted, wrote a description we didn't, and piled
+another commit on top. We *could* `jj undo` three times. But we know roughly
+where the good state was, so let's just go there. Find it in the log:
+
+```console
+$ jj op log --limit 6
+@  7fde600ecf01 steve@steves-laptop default@ now, lasted 9 milliseconds
+│  new empty commit
+│  args: jj new -m 'even more mess'
+○  1e8a46d3d6ab steve@steves-laptop default@ now, lasted 8 milliseconds
+│  describe commit 08a853a9e2b7
+│  args: jj describe -m 'a description I regret'
+○  a3ac895c94f3 steve@steves-laptop default@ now, lasted 11 milliseconds
+│  abandon commit 0570dd0df085
+│  args: jj abandon rxwzpxqt
+○  8112955b56b7 steve@steves-laptop default@ now, lasted 7 milliseconds
+│  undo: restore to operation 4079800aed31
+│  args: jj undo
+○  897f241ce8c8 steve@steves-laptop default@ now, lasted 10 milliseconds
+│  abandon commit 0570dd0df085
+│  args: jj abandon rxwzpxqt
+○  cac23ddcd31f steve@steves-laptop default@ now, lasted 12 milliseconds
+│  new empty commit
+│  args: jj new -m 'add a comment'
+```
+
+`cac23ddcd31f` is the last state before it all went wrong. `jj op restore` takes
+us there:
+
+```console
+$ jj op restore cac23ddcd31f
+Restored to operation: cac23ddcd31f (2024-03-20 09:14:20) new empty commit
+Working copy  (@) now at: rxwzpxqt 1e939d6c (empty) add a comment
+Parent commit (@-)      : zzzzmznr 3e44726c hello world
+Added 0 files, modified 1 files, removed 0 files
+```
+
+It's worth being clear about what happened here: `jj` restored the whole
+repository to that state. Anything that happened afterwards is no longer
+visible, including work we may have wanted to keep. `jj undo` steps back one
+operation at a time, while `jj op restore` goes straight to the state we name.
+Both are useful, but I pause for a moment before using `jj op restore` to make
+sure I've picked the right operation.
+
+And because `jj op restore` is itself an operation, it goes in the log too. If
+we restore to the wrong place, `jj undo` takes us back to the state before the
+restore. Let's look at one of those operations more closely.
+
+## Looking at a single operation
+
+`jj op show` tells you what one operation actually did. Let's look at that
+abandon from earlier, the one that started all this:
+
+```console
+$ jj op show a3ac895c94f3
+a3ac895c94f3 steve@steves-laptop default@ now, lasted 12 milliseconds
+abandon commit 0570dd0df0853eecc772025ef84a6b913243b1c7
+args: jj abandon rxwzpxqt
+
+Changed commits:
+○  + ozylkotm 9921e522 add goodbye
+   - ozylkotm/1 afc85298 (hidden) add goodbye
+○  - rxwzpxqt/0 0570dd0d (hidden) add a comment
+
+Changed working copy default@:
++ ozylkotm 9921e522 add goodbye
+- ozylkotm/1 afc85298 (hidden) add goodbye
+```
+
+Minus signs are commits that stopped being visible, plus signs are ones that
+started. You can read the whole mistake off this: `add a comment` went away, and
+`add goodbye` was replaced by a new version of itself — that's the automatic
+rebase onto the new parent.
+
+Note that word: *hidden*, not deleted. Those commits are still in the
+repository, which is exactly why undo works. Add `-p` if you want the file
+diffs as well.
+
+There's also `jj op diff`, which compares two operations rather than showing
+one, when you want to know what changed between two points in the afternoon.
+
+Operations cover the repository. Sometimes the question is narrower than that:
+not "what did I do to this repo?" but "what happened to *this one change*?"
+That's the next chapter.

--- a/src/fixing-problems/the-operation-log.md
+++ b/src/fixing-problems/the-operation-log.md
@@ -149,6 +149,18 @@ diffs as well.
 There's also `jj op diff`, which compares two operations rather than showing
 one, when you want to know what changed between two points in the afternoon.
 
+## Does this grow forever?
+
+You may be wondering: if every command is recorded, and hidden commits are
+kept around, doesn't the repository just grow without bound? Yes, it does —
+nothing prunes any of this automatically. In practice it takes a long time to
+matter, since operations and hidden commits are small. If a busy repository
+does get bulky, `jj op abandon ..<old-op-id>` marks old operations as
+disposable, and `jj util gc` then reclaims whatever nothing refers to any
+more. The price is exactly what you'd expect: you can no longer undo your way
+back past the operations you abandoned. I've never needed to do this, but it's
+good to know the ratchet has a release.
+
 Operations cover the repository. Sometimes the question is narrower than that:
 not "what did I do to this repo?" but "what happened to *this one change*?"
 That's the next chapter.

--- a/src/fixing-problems/undoing-mistakes.md
+++ b/src/fixing-problems/undoing-mistakes.md
@@ -1,0 +1,125 @@
+# Undoing mistakes with `jj undo`
+
+Let's make a mess on purpose. Here's a small repository with three changes:
+
+```console
+$ jj log
+@  ozylkotm steve@steveklabnik.com 2024-03-20 09:14:31 3c267bd1
+│  add goodbye
+○  rxwzpxqt steve@steveklabnik.com 2024-03-20 09:14:20 0570dd0d
+│  add a comment
+○  zzzzmznr steve@steveklabnik.com 2024-03-20 09:14:20 3e44726c
+│  hello world
+◆  zzzzzzzz root() 00000000
+```
+
+Now let's do something we regret. We meant to abandon some other change, but we
+typed the wrong one and threw away "add a comment":
+
+```console
+$ jj abandon rxwzpxqt
+Abandoned 1 commits:
+  rxwzpxqt 0570dd0d add a comment
+Rebased 1 descendant commits onto parents of abandoned commits.
+Working copy  (@) now at: ozylkotm 404f6b4e add goodbye
+Parent commit (@-)      : zzzzmznr 3e44726c hello world
+Added 0 files, modified 1 files, removed 0 files
+```
+
+It's gone, and `jj` helpfully rebased "add goodbye" onto "hello world" for us,
+so our work is now sitting on top of a commit that doesn't have the comment in
+it:
+
+```console
+$ jj log
+@  ozylkotm steve@steveklabnik.com 2024-03-20 09:14:31 404f6b4e
+│  add goodbye
+○  zzzzmznr steve@steveklabnik.com 2024-03-20 09:14:20 3e44726c
+│  hello world
+◆  zzzzzzzz root() 00000000
+```
+
+In `git`, recovering this change would take a few steps. In `jj`, we can run one
+command:
+
+```console
+$ jj undo
+Undid operation: 897f241ce8c8 (2024-03-20 09:14:31) abandon commit 0570dd0df085
+Restored to operation: 4079800aed31 (2024-03-20 09:14:20) snapshot working copy
+Working copy  (@) now at: ozylkotm 3c267bd1 add goodbye
+Parent commit (@-)      : rxwzpxqt 0570dd0d add a comment
+Added 0 files, modified 1 files, removed 0 files
+```
+
+And we're back:
+
+```console
+$ jj log
+@  ozylkotm steve@steveklabnik.com 2024-03-20 09:14:20 3c267bd1
+│  add goodbye
+○  rxwzpxqt steve@steveklabnik.com 2024-03-20 09:14:20 0570dd0d
+│  add a comment
+○  zzzzmznr steve@steveklabnik.com 2024-03-20 09:14:20 3e44726c
+│  hello world
+◆  zzzzzzzz root() 00000000
+```
+
+Notice that `rxwzpxqt` came back with the same change ID *and* the same commit
+ID, `0570dd0d`. This isn't a fresh commit that happens to have the same
+contents. It's the same commit; it was never really destroyed, just made
+invisible.
+
+## What `jj undo` actually undoes
+
+Here's the important bit: `jj undo` undoes the last *operation*, not the last
+*commit*. This is what makes it different from the closest commands in `git`.
+
+An operation is a recorded transition between repository states. Commands such
+as `jj abandon`, `jj describe`, `jj rebase`, and `jj new` create operations.
+Read-only commands don't. And — this surprises people — the automatic snapshot
+`jj` takes of your working copy can be a separate operation from the command
+that triggered it. Each operation records the complete state of the repository
+afterwards.
+
+So `jj undo` doesn't reason about what your command meant, or try to construct
+an inverse of it. It puts the repository back the way it was. That's why it
+works uniformly on every command, including ones that touched a dozen commits
+at once, and why the output tells you which operation it undid and which one it
+went back to.
+
+## Running it more than once
+
+There's one detail that can be surprising. If we run `jj undo` a second time,
+it does *not* undo the first undo:
+
+```console
+$ jj undo
+Undid operation: 4079800aed31 (2024-03-20 09:14:20) snapshot working copy
+Restored to operation: 84248e9a9cb9 (2024-03-20 09:14:20) new empty commit
+```
+
+Look at what it undid: the working copy snapshot from *before* the abandon.
+Repeated `jj undo` walks further and further back into the past, one operation
+at a time. It's a rewind button, not a toggle.
+
+If we do want to go the other way, there's `jj redo`:
+
+```console
+$ jj redo
+Restored to operation: c8fa9084a76c (2024-03-20 09:14:20) undo: restore to operation 4079800aed31
+Working copy  (@) now at: ozylkotm 3c267bd1 add goodbye
+Parent commit (@-)      : rxwzpxqt 0570dd0d add a comment
+```
+
+`jj redo` moves in the direction of the future, so between the two of them you
+can scrub back and forth until you find the state you wanted.
+
+## Undoing something other than the last thing
+
+Rewinding one step at a time is fine when you've just made one mistake. When
+you've made four, and you only want to reach past three of them, you want to
+name the state you're going back to directly. `jj undo` won't help there — it
+takes no arguments, and only ever walks backwards from where you are.
+
+For that you need to see the operations and refer to them by name, and that's
+the operation log. Let's look at it.

--- a/src/hello-world/creating-a-repository.md
+++ b/src/hello-world/creating-a-repository.md
@@ -69,10 +69,11 @@ $ git log --oneline
 c4b8fac hello world
 ```
 
-Don't use this as an excuse to run `git` commands that *change* things, though.
-Let `jj` do the mutating, or the two tools will fight over the same store. If
-you'd rather not have a `.git` directory at all, pass `--no-colocate`, and the
-`git` repository gets tucked away inside `.jj` where other tools can't see it.
+Because both tools share one store, we'll let `jj` make changes to the
+repository and use `git` for reading it. We'll look at the details later in the
+tutorial. If we'd rather not have a `.git` directory at all, we can pass
+`--no-colocate`; the Git repository then lives inside `.jj`, where other tools
+won't discover it automatically.
 
 Anyway, now we've got a repository! In the next section, we'll take a peek
 inside.

--- a/src/hello-world/creating-a-repository.md
+++ b/src/hello-world/creating-a-repository.md
@@ -59,10 +59,11 @@ $ ls -d .git .jj
 ```
 
 This is called a "colocated" repository: a `.jj` directory and a real `.git`
-directory side by side, over one working copy. It's the default. `jj` imports
-from and exports to the `git` repository on every command, so `git`, `gh`, your
-editor, and CI all see a perfectly normal `git` repo. `git log` will show you
-the commits you make with `jj`:
+directory side by side, over one working copy. It's the default, and it's what
+we'll use throughout this tutorial. `jj` imports from and exports to the `git`
+repository on every command, so `git`, `gh`, your editor, and CI all see a
+perfectly normal `git` repo. `git log` will show you the commits you make with
+`jj`:
 
 ```console
 $ git log --oneline
@@ -71,9 +72,10 @@ c4b8fac hello world
 
 Because both tools share one store, we'll let `jj` make changes to the
 repository and use `git` for reading it. We'll look at the details later in the
-tutorial. If we'd rather not have a `.git` directory at all, we can pass
-`--no-colocate`; the Git repository then lives inside `.jj`, where other tools
-won't discover it automatically.
+tutorial. There is an escape hatch, `--no-colocate`, for workflows that need to
+keep Git-aware tools away from the working copy. Unless we have a specific
+reason to make that tradeoff, the colocated default is the useful place to
+start.
 
 Anyway, now we've got a repository! In the next section, we'll take a peek
 inside.

--- a/src/hello-world/creating-a-repository.md
+++ b/src/hello-world/creating-a-repository.md
@@ -45,7 +45,34 @@ Initialized repo in "."
 Now, you may be wondering, "why not just `jj init`?" The deal is this: the
 native repository format is still a work in progress. So we're creating a
 repository that's backed by a real `git` repository, because in practice, this
-early in `jj`'s life, that's the right thing to do.
+early in `jj`'s life, that's the right thing to do. There's no `jj init`
+command at all; if you type it, `jj` will tell you that you probably wanted
+`jj git init`.
+
+If you peek at the directory listing, you'll notice something: `jj git init`
+made *two* directories.
+
+```console
+$ ls -d .git .jj
+.git
+.jj
+```
+
+This is called a "colocated" repository: a `.jj` directory and a real `.git`
+directory side by side, over one working copy. It's the default. `jj` imports
+from and exports to the `git` repository on every command, so `git`, `gh`, your
+editor, and CI all see a perfectly normal `git` repo. `git log` will show you
+the commits you make with `jj`:
+
+```console
+$ git log --oneline
+c4b8fac hello world
+```
+
+Don't use this as an excuse to run `git` commands that *change* things, though.
+Let `jj` do the mutating, or the two tools will fight over the same store. If
+you'd rather not have a `.git` directory at all, pass `--no-colocate`, and the
+`git` repository gets tucked away inside `.jj` where other tools can't see it.
 
 Anyway, now we've got a repository! In the next section, we'll take a peek
 inside.

--- a/src/hello-world/creating-a-repository.md
+++ b/src/hello-world/creating-a-repository.md
@@ -62,13 +62,10 @@ This is called a "colocated" repository: a `.jj` directory and a real `.git`
 directory side by side, over one working copy. It's the default, and it's what
 we'll use throughout this tutorial. `jj` imports from and exports to the `git`
 repository on every command, so `git`, `gh`, your editor, and CI all see a
-perfectly normal `git` repo. `git log` will show you the commits you make with
-`jj`:
-
-```console
-$ git log --oneline
-c4b8fac hello world
-```
+perfectly normal `git` repo. Mind you, if you run `git log` right this second,
+it will complain that there aren't any commits yet — we haven't made any! Once
+we have some history, `git log` will show the commits we make with `jj`, and
+we'll see exactly that later in the tutorial.
 
 Because both tools share one store, we'll let `jj` make changes to the
 repository and use `git` for reading it. We'll look at the details later in the

--- a/src/hello-world/creating-new-changes.md
+++ b/src/hello-world/creating-new-changes.md
@@ -5,8 +5,8 @@ that work by using `jj new`:
 
 ```console
 $ jj new
-Working copy now at: puomrwxl 01a35aad (empty) (no description set)
-Parent commit      : yyrsmnoo ac691d85 hello world
+Working copy  (@) now at: puomrwxl 01a35aad (empty) (no description set)
+Parent commit (@-)      : yyrsmnoo ac691d85 hello world
 ```
 
 It's that easy! We now have a new change, `puomrwxl`, that's empty and has
@@ -16,9 +16,9 @@ Let's check out `jj st`:
 
 ```console
 $ jj st
-The working copy is clean
-Working copy : puomrwxl 01a35aad (empty) (no description set)
-Parent commit: yyrsmnoo ac691d85 hello world
+The working copy has no changes.
+Working copy  (@) : puomrwxl 01a35aad (empty) (no description set)
+Parent commit (@-): yyrsmnoo ac691d85 hello world
 ```
 
 Nice, a clean working copy: all of our changes were made in `yyrsmnoo`, and
@@ -30,8 +30,8 @@ change. This time, I'm going to describe things first, before I make any changes
 
 ```console
 > jj describe -m "it's important to comment our code"
-Working copy now at: puomrwxl a0f0bc71 (empty) it's important to comment our code
-Parent commit      : yyrsmnoo ac691d85 hello world
+Working copy  (@) now at: puomrwxl a0f0bc71 (empty) it's important to comment our code
+Parent commit (@-)      : yyrsmnoo ac691d85 hello world
 ```
 
 Just what we expected, still an empty change, but with a description, and our
@@ -53,8 +53,8 @@ We can double check that `jj` has noticed our change:
 $ jj st
 Working copy changes:
 M src/main.rs
-Working copy : puomrwxl 7a096b8a it's important to comment our code
-Parent commit: yyrsmnoo ac691d85 hello world
+Working copy  (@) : puomrwxl 7a096b8a it's important to comment our code
+Parent commit (@-): yyrsmnoo ac691d85 hello world
 ```
 
 Excellent, `src/main.rs` has been `M`odified, we have a new commit ID. Since
@@ -62,8 +62,8 @@ we're done with this change, let's start a new one:
 
 ```console
 $ jj new
-Working copy now at: ywnkulko 46b50ed7 (empty) (no description set)
-Parent commit      : puomrwxl 7a096b8a it's important to comment our code
+Working copy  (@) now at: ywnkulko 46b50ed7 (empty) (no description set)
+Parent commit (@-)      : puomrwxl 7a096b8a it's important to comment our code
 ```
 
 Wonderful.

--- a/src/hello-world/creating-new-changes.md
+++ b/src/hello-world/creating-new-changes.md
@@ -52,12 +52,12 @@ We can double check that `jj` has noticed our change:
 ```console
 $ jj st
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : puomrwxl 7a096b8a it's important to comment our code
 Parent commit: yyrsmnoo ac691d85 hello world
 ```
 
-Excellent, `src\main.rs` has been `M`odified, we have a new commit ID. Since
+Excellent, `src/main.rs` has been `M`odified, we have a new commit ID. Since
 we're done with this change, let's start a new one:
 
 ```console

--- a/src/hello-world/describing-commits.md
+++ b/src/hello-world/describing-commits.md
@@ -8,11 +8,36 @@ Let's set some quick configuration:
 
 ```console
 $ jj config set --user user.name "Steve Klabnik"
+Warning: This setting will only impact future commits.
+The author of the working copy will stay "you <you@example.com>".
+To change the working copy author, use "jj metaedit --update-author".
 $ jj config set --user user.email "steve@steveklabnik.com"
+Warning: This setting will only impact future commits.
+The author of the working copy will stay "you <you@example.com>".
+To change the working copy author, use "jj metaedit --update-author".
 ```
 
 Obviously, unless you're me, you should be putting your own name and email in
-there. Okay, with that out of the way, we're ready to describe some changes.
+there.
+
+About that warning: we created our repository before we set our identity, and
+`jj` had already made a working copy change for us at that point, stamped with
+whatever identity it could find. Changing the setting doesn't reach back and
+rewrite it. Since our first change is about to be described anyway, let's just
+fix the author on it:
+
+```console
+$ jj metaedit --update-author
+Modified 1 commits:
+  qzmzpxyl bc915fcd (no description set)
+Working copy  (@) now at: qzmzpxyl bc915fcd (no description set)
+Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
+```
+
+`jj metaedit` changes a commit's metadata without touching its contents. Set
+your identity before `jj git init` next time and you'll never see the warning.
+
+Okay, with that out of the way, we're ready to describe some changes.
 
 Whenever we feel like it, we can describe our changes with `jj describe`.
 The simplest way to use it is with the `-m`, or "message" flag. This allows us

--- a/src/hello-world/describing-commits.md
+++ b/src/hello-world/describing-commits.md
@@ -20,8 +20,8 @@ to pass the description on the command line:
 
 ```console
 $ jj describe -m "hello world"
-Working copy now at: yyrsmnoo 524d2bf4 hello world
-Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+Working copy  (@) now at: yyrsmnoo 524d2bf4 hello world
+Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
 ```
 
 (You may notice that the change ID changed here: that's just some book-writing
@@ -69,8 +69,8 @@ JJ: Lines starting with "JJ: " (like this one) will be removed.
 After saving and closing, we'll get this output:
 
 ```console
-Working copy now at: yyrsmnoo ac691d85 hello world
-Parent commit      : zzzzzzzz 00000000 (empty) (no description set)
+Working copy  (@) now at: yyrsmnoo ac691d85 hello world
+Parent commit (@-)      : zzzzzzzz 00000000 (empty) (no description set)
 ```
 
 We only see that first line, but the rest are still there.
@@ -79,8 +79,8 @@ Eagle eyed readers may notice one other change. Let's take two of these outputs
 and put them next to each other:
 
 ```text
-Working copy now at: yyrsmnoo 524d2bf4 hello world
-Working copy now at: yyrsmnoo ac691d85 hello world
+Working copy  (@) now at: yyrsmnoo 524d2bf4 hello world
+Working copy  (@) now at: yyrsmnoo ac691d85 hello world
 ```
 
 Changing our description changed the commit ID! This is why we have both IDs:

--- a/src/hello-world/describing-commits.md
+++ b/src/hello-world/describing-commits.md
@@ -61,7 +61,7 @@ JJ: This commit contains the following changes:
 JJ:     A .gitignore
 JJ:     A Cargo.lock
 JJ:     A Cargo.toml
-JJ:     A src\main.rs
+JJ:     A src/main.rs
 
 JJ: Lines starting with "JJ: " (like this one) will be removed.
 ```

--- a/src/hello-world/hello-world.md
+++ b/src/hello-world/hello-world.md
@@ -9,3 +9,5 @@ Here's what we're going to learn:
 * Using `jj describe` to describe our commits in a human-friendly way
 * Using `jj new` to create new changes
 * Viewing the contents of your repository with `jj log`
+* Seeing what changed with `jj diff` and `jj show`
+* Which files `jj` tracks, and how to ignore the rest

--- a/src/hello-world/how-to-install.md
+++ b/src/hello-world/how-to-install.md
@@ -1,6 +1,6 @@
 # How to install `jj`
 
-This tutorial is written when `jj` is at version 0.23.0. It may work for
+This tutorial is written when `jj` is at version 0.44.0. It may work for
 later versions, but you also may need to adapt.
 
 For the full range of ways to install `jj`, you can visit the [Installation and
@@ -10,7 +10,7 @@ a Rust developer, and `jj` is written in Rust, I installed my copy like this:
 [install]: https://docs.jj-vcs.dev/latest/install-and-setup/
 
 ```console
-$ cargo install jj-cli@0.23.0 --locked
+$ cargo install jj-cli@0.44.0 --locked
 ```
 
 If you're not a Rust developer, please read the documentation to figure out how

--- a/src/hello-world/how-to-install.md
+++ b/src/hello-world/how-to-install.md
@@ -1,6 +1,6 @@
 # How to install `jj`
 
-This tutorial is written when `jj` is at version 0.44.0. It may work for
+This tutorial is written when `jj` is at version 0.45.1. It may work for
 later versions, but you also may need to adapt.
 
 For the full range of ways to install `jj`, you can visit the [Installation and
@@ -10,7 +10,7 @@ a Rust developer, and `jj` is written in Rust, I installed my copy like this:
 [install]: https://docs.jj-vcs.dev/latest/install-and-setup/
 
 ```console
-$ cargo install jj-cli@0.44.0 --locked
+$ cargo install jj-cli@0.45.1 --locked
 ```
 
 If you're not a Rust developer, please read the documentation to figure out how

--- a/src/hello-world/recap.md
+++ b/src/hello-world/recap.md
@@ -8,7 +8,8 @@ So here is our current workflow:
 4. We can look at our work with `jj st`.
 5. When we're done, we can start our next change with `jj new`.
 
-Finally, we can review our repository's contents with `jj log`.
+Finally, we can review our repository's contents with `jj log`, and look at
+what any individual change actually does with `jj diff` and `jj show`.
 
 Steps 3 and 5 are common enough together that there's a shorthand for them:
 `jj commit -m "message"` describes the current change and then starts a new one

--- a/src/hello-world/recap.md
+++ b/src/hello-world/recap.md
@@ -10,6 +10,13 @@ So here is our current workflow:
 
 Finally, we can review our repository's contents with `jj log`.
 
+Steps 3 and 5 are common enough together that there's a shorthand for them:
+`jj commit -m "message"` describes the current change and then starts a new one
+on top, which is exactly `jj describe` followed by `jj new`. It reads like
+`git commit`, which makes it a comfortable landing spot on your way in. I'll
+keep using the two separate commands in this book, because they make it clearer
+which of the two things is happening.
+
 This is... pretty simple! We don't need that many concepts to get started.
 Of course, we aren't yet able to do some very important things like "share our
 code with others." But we'll get there.

--- a/src/hello-world/tracking-files.md
+++ b/src/hello-world/tracking-files.md
@@ -13,8 +13,8 @@ $ echo "secret" > secrets.env
 $ jj st
 Working copy changes:
 A secrets.env
-Working copy  (@) : rsrkkypy 5709764b (no description set)
-Parent commit (@-): pqxxuvwy 8ed64743 second line
+Working copy  (@) : ywnkulko 0c334409 (no description set)
+Parent commit (@-): puomrwxl 7a096b8a it's important to comment our code
 ```
 
 There's no staging area, so there's nothing to add things to. Remember, `@` is
@@ -27,33 +27,36 @@ want `secrets.env` in a commit. Let's see how to keep it out.
 
 ## Ignoring files
 
-`jj` reads `.gitignore`, with the same syntax you already know:
+`jj` reads `.gitignore`, with the same syntax you already know. We already have
+one, from back when we created the project — it keeps `cargo`'s build output
+out of our repository. Let's add a rule to it:
 
 ```console
-$ echo "*.env" > .gitignore
+$ echo "*.env" >> .gitignore
 
 $ jj st
 Working copy changes:
-A .gitignore
+M .gitignore
 A secrets.env
-Working copy  (@) : rsrkkypy 6b873e2a (no description set)
-Parent commit (@-): pqxxuvwy 8ed64743 second line
+Working copy  (@) : ywnkulko 6ac6112a (no description set)
+Parent commit (@-): puomrwxl 7a096b8a it's important to comment our code
 ```
 
-`.gitignore` shows up because it's a normal file, and you want it committed so
-that everyone working on the project ignores the same things. `secrets.env`
-shows up too: the previous `jj st` snapshotted it into `@`, so it's already
-tracked. Adding an ignore rule never removes a tracked file, exactly as in
-`git`. That's what `jj file untrack` is for:
+`.gitignore` shows up as `M`odified, which makes sense: it's a normal, tracked
+file, and you want it committed so that everyone working on the project ignores
+the same things. But `secrets.env` still shows up too! The previous `jj st`
+snapshotted it into `@`, so it's already tracked. Adding an ignore rule never
+removes a tracked file, exactly as in `git`. That's what `jj file untrack` is
+for:
 
 ```console
 $ jj file untrack secrets.env
 
 $ jj st
 Working copy changes:
-A .gitignore
-Working copy  (@) : rsrkkypy 1c7d8fe0 (no description set)
-Parent commit (@-): pqxxuvwy 8ed64743 second line
+M .gitignore
+Working copy  (@) : ywnkulko f77fddd4 (no description set)
+Parent commit (@-): puomrwxl 7a096b8a it's important to comment our code
 ```
 
 The file is out of the commit and still on disk, which is what you want for
@@ -61,14 +64,14 @@ something like a local config file:
 
 ```console
 $ ls
-notes.txt    secrets.env
+Cargo.lock    Cargo.toml    secrets.env    src
 ```
 
 `jj` insists you ignore it first:
 
 ```console
-$ jj file untrack notes.txt
-Error: 'notes.txt' is not ignored.
+$ jj file untrack Cargo.toml
+Error: 'Cargo.toml' is not ignored.
 Hint: Files that are not ignored will be added back by the next command.
 Make sure they're ignored, then try again.
 ```
@@ -88,9 +91,12 @@ There are a handful of other useful commands under `jj file`. We can read a
 file as of a particular change without touching our working copy:
 
 ```console
-$ jj file show -r @- notes.txt
-line one
-line two
+$ jj file show -r @- src/main.rs
+/// A "Hello, world!" program.
+
+fn main() {
+    println!("Hello, world!");
+}
 ```
 
 Listing what a revision contains:
@@ -98,25 +104,36 @@ Listing what a revision contains:
 ```console
 $ jj file list
 .gitignore
-notes.txt
+Cargo.lock
+Cargo.toml
+src/main.rs
 ```
 
 Searching the tracked files:
 
 ```console
-$ jj file search --pattern "line two" .
-notes.txt:line two
+$ jj file search --pattern "Hello" .
+src/main.rs:/// A "Hello, world!" program.
+src/main.rs:    println!("Hello, world!");
 ```
 
 And here's one worth remembering, because the name may not suggest it at first.
 `jj file annotate` is the equivalent of `git blame`:
 
 ```console
-$ jj file annotate notes.txt
-mtvqnnvv steve    2024-03-27 14:31:39    1: line one
-pqxxuvwy steve    2024-03-27 14:31:39    2: line two
+$ jj file annotate src/main.rs
+puomrwxl steve@st 2024-02-28 20:38:13    1: /// A "Hello, world!" program.
+puomrwxl steve@st 2024-02-28 20:38:13    2: 
+yyrsmnoo steve@st 2024-02-28 20:24:56    3: fn main() {
+yyrsmnoo steve@st 2024-02-28 20:24:56    4:     println!("Hello, world!");
+yyrsmnoo steve@st 2024-02-28 20:24:56    5: }
 ```
 
 We get each line along with the change that last touched it. The first column is
 a change ID, so we can pass it straight to `jj show` to see what that change
 was doing.
+
+That's it for our tour of the basics. Before we recap, let's clean up after
+this experiment: delete `secrets.env`, and take the `*.env` line back out of
+`.gitignore`. That leaves our working copy empty again, ready for the next
+section.

--- a/src/hello-world/tracking-files.md
+++ b/src/hello-world/tracking-files.md
@@ -1,0 +1,122 @@
+# Which files `jj` tracks
+
+You may have noticed something missing. We've created a bunch of files, and
+they've shown up in our commits, but at no point did we run anything like
+`git add`. Let's talk about why.
+
+New files are tracked automatically. If we make one, it will be part of our
+working copy commit:
+
+```console
+$ echo "secret" > secrets.env
+
+$ jj st
+Working copy changes:
+A secrets.env
+Working copy  (@) : rsrkkypy 5709764b (no description set)
+Parent commit (@-): pqxxuvwy 8ed64743 second line
+```
+
+There's no staging area, so there's nothing to add things to. Remember, `@` is
+a commit, and its contents are whatever is in our working directory. This is
+the same snapshotting we've relied on all along, even for files that didn't
+exist before.
+
+This is convenient, but that file has a suspicious name! We probably didn't
+want `secrets.env` in a commit. Let's see how to keep it out.
+
+## Ignoring files
+
+`jj` reads `.gitignore`, with the same syntax you already know:
+
+```console
+$ echo "*.env" > .gitignore
+
+$ jj st
+Working copy changes:
+A .gitignore
+A secrets.env
+Working copy  (@) : rsrkkypy 6b873e2a (no description set)
+Parent commit (@-): pqxxuvwy 8ed64743 second line
+```
+
+`.gitignore` shows up because it's a normal file, and you want it committed so
+that everyone working on the project ignores the same things. `secrets.env`
+shows up too: the previous `jj st` snapshotted it into `@`, so it's already
+tracked. Adding an ignore rule never removes a tracked file, exactly as in
+`git`. That's what `jj file untrack` is for:
+
+```console
+$ jj file untrack secrets.env
+
+$ jj st
+Working copy changes:
+A .gitignore
+Working copy  (@) : rsrkkypy 1c7d8fe0 (no description set)
+Parent commit (@-): pqxxuvwy 8ed64743 second line
+```
+
+The file is out of the commit and still on disk, which is what you want for
+something like a local config file:
+
+```console
+$ ls
+notes.txt    secrets.env
+```
+
+`jj` insists you ignore it first:
+
+```console
+$ jj file untrack notes.txt
+Error: 'notes.txt' is not ignored.
+Hint: Files that are not ignored will be added back by the next command.
+Make sure they're ignored, then try again.
+```
+
+This may seem fussy, but it makes sense. If the file wasn't ignored, `jj` would
+track it again the next time it took a snapshot. Requiring both steps keeps us
+from thinking we ignored something when we didn't.
+
+One thing this doesn't do: untracking removes the file from `@` going forward,
+not from history. A password you committed five changes ago is still in those
+changes, and still in what you push. Getting it out of the past is a rewrite,
+not an untrack.
+
+## Looking inside files
+
+There are a handful of other useful commands under `jj file`. We can read a
+file as of a particular change without touching our working copy:
+
+```console
+$ jj file show -r @- notes.txt
+line one
+line two
+```
+
+Listing what a revision contains:
+
+```console
+$ jj file list
+.gitignore
+notes.txt
+```
+
+Searching the tracked files:
+
+```console
+$ jj file search --pattern "line two" .
+notes.txt:line two
+```
+
+And here's one worth remembering, because the name may not suggest it at first.
+`jj file annotate` is the equivalent of `git blame`:
+
+```console
+$ jj file annotate notes.txt
+mtvqnnvv steve    2024-03-27 14:31:39    1: line one
+pqxxuvwy steve    2024-03-27 14:31:39    2: line two
+```
+
+We get each line along with the change that last touched it. The first column is
+a change ID, so we can pass it straight to `jj show` to see what that change
+was doing.

--- a/src/hello-world/viewing-changes.md
+++ b/src/hello-world/viewing-changes.md
@@ -1,0 +1,146 @@
+# Seeing what changed with `jj diff` and `jj show`
+
+So far, `jj st` has told us *which* files we've touched, and `jj log` has told
+us which changes exist. Neither tells us what's actually in those changes. For
+that, we can use `jj diff`:
+
+```console
+$ jj diff
+Modified regular file main.rs:
+   1    1: fn main() {
+   2    2:     println!("Hello, world!");
+        3:     println!("Goodbye, world!");
+   3    4: }
+```
+
+With no arguments it shows what's in `@`: the difference between your working
+copy and its parent. Since your working copy is a commit like any other, that's
+the same thing as "what this commit contains".
+
+This format can take a moment to read if you're used to `git`. There are two
+columns of line numbers: the line's position before, and after. A line present
+in both gets both numbers. A line only in the new version, like our `Goodbye`,
+has an empty left column. Deleted lines are the other way round:
+
+```console
+$ jj diff
+Modified regular file main.rs:
+   1    1: fn main() {
+   2     :     println!("Hello, world!");
+        2:     println!("Hi!");
+   3    3: }
+```
+
+Line 2 went away and a new line 2 arrived. In a terminal this is colored, and
+`jj` highlights the words that differ rather than just the lines, which is why
+it's called a "color words" diff. It's good at showing small edits inside long
+lines, where `git`'s line-at-a-time view makes you hunt.
+
+If you'd rather have the format every other tool understands:
+
+```console
+$ jj diff --git
+diff --git a/main.rs b/main.rs
+index e7a11a969c..4e787b01da 100644
+--- a/main.rs
++++ b/main.rs
+@@ -1,3 +1,4 @@
+ fn main() {
+     println!("Hello, world!");
++    println!("Goodbye, world!");
+ }
+```
+
+This is handy when we want to paste a patch somewhere. We can also use `-s` to
+get just the summary, which is the same list of names `jj st` shows:
+
+```console
+$ jj diff -s
+M main.rs
+```
+
+## Any change, not just this one
+
+We can use `-r` to show a different change:
+
+```console
+$ jj diff -r @-
+Added regular file main.rs:
+        1: fn main() {
+        2:     println!("Hello, world!");
+        3: }
+```
+
+An added file has nothing in the left column at all, which makes sense — none of
+it was there before.
+
+`--from` and `--to` compare two revisions that needn't be adjacent:
+
+```console
+$ jj diff --from @-- --to @
+Modified regular file main.rs:
+   1    1: fn main() {
+   2     :     println!("Hello, world!");
+        2:     println!("Hi!");
+        3:     println!("Goodbye, world!");
+   3    4: }
+```
+
+This is the combined effect of two changes. I find this useful before pushing:
+`jj diff --from trunk` shows everything our branch does.
+
+## `jj show`
+
+`jj diff` shows us the contents of a change. `jj show` adds who made it, when
+they made it, and why:
+
+```console
+$ jj show
+Commit ID: 8ad74e791c831f2f39cdde695fce5e7553b85f4c
+Change ID: wvokwvnpzwqkmmxzsruqvmwpzkxuupom
+Author   : Steve Klabnik <steve@steveklabnik.com> (2024-03-26 11:04:04)
+Committer: Steve Klabnik <steve@steveklabnik.com> (2024-03-26 11:04:05)
+
+    add a goodbye
+
+Modified regular file main.rs:
+   1    1: fn main() {
+   2    2:     println!("Hello, world!");
+        3:     println!("Goodbye, world!");
+   3    4: }
+```
+
+We get both IDs in full, both timestamps, the description, and the diff.
+`jj show -r` takes a revision in the same way. I tend to use `jj show` when I'm
+inspecting somebody else's commit, and `jj diff` when I'm checking my own work.
+
+Note the two timestamps. Author is when the change was first made; committer is
+when this version of it was written. Rewrite a commit — amend it, rebase it —
+and the second moves while the first stays put.
+
+## Comparing two versions of the same change
+
+There's a third command for a situation `git` doesn't handle very well. Let's
+say we've pushed a pull request, someone has reviewed it, and then we've
+rewritten the change. We may want to know what changed between those two
+versions, rather than what the change itself does.
+
+```console
+$ jj interdiff --from 64fe802a --to @
+Modified commit description:
+   1     : feature v1
+        1: feature v2
+Modified regular file feat.txt:
+   1     : one
+        1: one and two
+```
+
+That's `jj interdiff`, and it compares the *effects* of two commits rather than
+their contents, so the work underneath them doesn't get in the way. The old
+commit ID comes from `jj evolog`, which we'll meet properly later — it keeps
+every version of a change, so the thing the reviewer saw is still there to
+compare against.
+
+I find it surprisingly useful to be able to answer "what did you change since
+my review?" precisely. This is another benefit of `jj` keeping old versions of
+our changes rather than overwriting them.

--- a/src/hello-world/viewing-changes.md
+++ b/src/hello-world/viewing-changes.md
@@ -2,15 +2,31 @@
 
 So far, `jj st` has told us *which* files we've touched, and `jj log` has told
 us which changes exist. Neither tells us what's actually in those changes. For
-that, we can use `jj diff`:
+that, we can use `jj diff`.
+
+First, let's give ourselves something to look at. Our working copy is sitting
+at an empty change, so let's make an edit to `src/main.rs`:
+
+```rust
+/// A "Hello, world!" program.
+
+fn main() {
+    println!("Hello, world!");
+    println!("Goodbye, world!");
+}
+```
+
+Now we can ask what we've done:
 
 ```console
 $ jj diff
-Modified regular file main.rs:
-   1    1: fn main() {
-   2    2:     println!("Hello, world!");
-        3:     println!("Goodbye, world!");
-   3    4: }
+Modified regular file src/main.rs:
+   1    1: /// A "Hello, world!" program.
+   2    2: 
+   3    3: fn main() {
+   4    4:     println!("Hello, world!");
+        5:     println!("Goodbye, world!");
+   5    6: }
 ```
 
 With no arguments it shows what's in `@`: the difference between your working
@@ -20,18 +36,22 @@ the same thing as "what this commit contains".
 This format can take a moment to read if you're used to `git`. There are two
 columns of line numbers: the line's position before, and after. A line present
 in both gets both numbers. A line only in the new version, like our `Goodbye`,
-has an empty left column. Deleted lines are the other way round:
+has an empty left column. Deleted lines are the other way round. Suppose that
+instead of adding a goodbye, we had replaced the hello with something else.
+Then we'd see:
 
 ```console
 $ jj diff
-Modified regular file main.rs:
-   1    1: fn main() {
-   2     :     println!("Hello, world!");
-        2:     println!("Hi!");
-   3    3: }
+Modified regular file src/main.rs:
+   1    1: /// A "Hello, world!" program.
+   2    2: 
+   3    3: fn main() {
+   4     :     println!("Hello, world!");
+        4:     println!("Hi!");
+   5    5: }
 ```
 
-Line 2 went away and a new line 2 arrived. In a terminal this is colored, and
+Line 4 went away and a new line 4 arrived. In a terminal this is colored, and
 `jj` highlights the words that differ rather than just the lines, which is why
 it's called a "color words" diff. It's good at showing small edits inside long
 lines, where `git`'s line-at-a-time view makes you hunt.
@@ -40,11 +60,12 @@ If you'd rather have the format every other tool understands:
 
 ```console
 $ jj diff --git
-diff --git a/main.rs b/main.rs
-index e7a11a969c..4e787b01da 100644
---- a/main.rs
-+++ b/main.rs
-@@ -1,3 +1,4 @@
+diff --git a/src/main.rs b/src/main.rs
+index a4fd3383fc..ba1a7af2a4 100644
+--- a/src/main.rs
++++ b/src/main.rs
+@@ -2,4 +2,5 @@
+ 
  fn main() {
      println!("Hello, world!");
 +    println!("Goodbye, world!");
@@ -56,38 +77,44 @@ get just the summary, which is the same list of names `jj st` shows:
 
 ```console
 $ jj diff -s
-M main.rs
+M src/main.rs
 ```
 
 ## Any change, not just this one
 
-We can use `-r` to show a different change:
+We can use `-r` to show a different change. Let's look at the parent of our
+working copy, the one where we added that comment:
 
 ```console
 $ jj diff -r @-
-Added regular file main.rs:
-        1: fn main() {
-        2:     println!("Hello, world!");
-        3: }
+Modified regular file src/main.rs:
+        1: /// A "Hello, world!" program.
+        2: 
+   1    3: fn main() {
+   2    4:     println!("Hello, world!");
+   3    5: }
 ```
 
-An added file has nothing in the left column at all, which makes sense — none of
-it was there before.
+There are our two new lines, with nothing in their left columns. A file that's
+new in a change looks like this for its whole contents — an empty left column
+all the way down, since none of it was there before.
 
 `--from` and `--to` compare two revisions that needn't be adjacent:
 
 ```console
 $ jj diff --from @-- --to @
-Modified regular file main.rs:
-   1    1: fn main() {
-   2     :     println!("Hello, world!");
-        2:     println!("Hi!");
-        3:     println!("Goodbye, world!");
-   3    4: }
+Modified regular file src/main.rs:
+        1: /// A "Hello, world!" program.
+        2: 
+   1    3: fn main() {
+   2    4:     println!("Hello, world!");
+        5:     println!("Goodbye, world!");
+   3    6: }
 ```
 
-This is the combined effect of two changes. I find this useful before pushing:
-`jj diff --from trunk` shows everything our branch does.
+This is the combined effect of two changes: the comment from the parent, and
+the goodbye from the working copy, in one diff. I find this useful before
+pushing: `jj diff --from 'trunk()'` shows everything our branch does.
 
 ## `jj show`
 
@@ -95,19 +122,20 @@ This is the combined effect of two changes. I find this useful before pushing:
 they made it, and why:
 
 ```console
-$ jj show
-Commit ID: 8ad74e791c831f2f39cdde695fce5e7553b85f4c
-Change ID: wvokwvnpzwqkmmxzsruqvmwpzkxuupom
-Author   : Steve Klabnik <steve@steveklabnik.com> (2024-03-26 11:04:04)
-Committer: Steve Klabnik <steve@steveklabnik.com> (2024-03-26 11:04:05)
+$ jj show @-
+Commit ID: 7a096b8a2a7108ebfe30e05e7d38ee0dc77b9b29
+Change ID: puomrwxlkmpxwnnrtqoumzlsvqzkuxpn
+Author   : Steve Klabnik <steve@steveklabnik.com> (2024-02-28 20:38:13)
+Committer: Steve Klabnik <steve@steveklabnik.com> (2024-02-28 20:38:13)
 
-    add a goodbye
+    it's important to comment our code
 
-Modified regular file main.rs:
-   1    1: fn main() {
-   2    2:     println!("Hello, world!");
-        3:     println!("Goodbye, world!");
-   3    4: }
+Modified regular file src/main.rs:
+        1: /// A "Hello, world!" program.
+        2: 
+   1    3: fn main() {
+   2    4:     println!("Hello, world!");
+   3    5: }
 ```
 
 We get both IDs in full, both timestamps, the description, and the diff.
@@ -144,3 +172,16 @@ compare against.
 I find it surprisingly useful to be able to answer "what did you change since
 my review?" precisely. This is another benefit of `jj` keeping old versions of
 our changes rather than overwriting them.
+
+Before we move on, let's put `src/main.rs` back the way it was. This goodbye
+was just something to point our new commands at; delete that line again, and
+`jj st` will confirm we're back to a clean, empty change:
+
+```console
+$ jj st
+The working copy has no changes.
+Working copy  (@) : ywnkulko 0b3dd9d2 (empty) (no description set)
+Parent commit (@-): puomrwxl 7a096b8a it's important to comment our code
+```
+
+Don't worry, we'll write a real goodbye feature soon enough.

--- a/src/hello-world/viewing-contents.md
+++ b/src/hello-world/viewing-contents.md
@@ -42,9 +42,11 @@ than the others: `◆` instead of `○`. That shape means the commit is
 *immutable*: `jj` will refuse to rewrite it. That makes sense for the root
 commit, which is the foundation the whole repository is built on. Right now
 it's the only immutable commit we have. Once we start sharing code, `jj` will
-also protect commits selected by its immutability policy, such as trunk and
-tags. A pushed feature commit is not necessarily immutable; we'll return to the
-exact rules when we work with remotes.
+also protect commits selected by its immutability policy, such as *trunk* and
+tags. Trunk is the main line of development everyone shares — usually the `main`
+branch on the `origin` remote, which `jj` writes `main@origin`. A pushed feature
+commit is not necessarily immutable; we'll return to the exact rules when we work
+with remotes.
 
 One more thing: my text representation of the output of `jj log` was missing
 something. Here's a screenshot of my terminal, and you may notice something

--- a/src/hello-world/viewing-contents.md
+++ b/src/hello-world/viewing-contents.md
@@ -4,13 +4,13 @@ Let's look at our chain of changes:
 
 ```console
 > jj log
-@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00.000 -06:00 46b50ed7
+@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00 46b50ed7
 │  (empty) (no description set)
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 As you can see, this is sort of like `git log`, but also very different. There's

--- a/src/hello-world/viewing-contents.md
+++ b/src/hello-world/viewing-contents.md
@@ -37,6 +37,15 @@ But the short of it is this: `jj` has a really powerful way to select lists
 of revisions. `root()` is a function in this language (yes, it has functions)
 that returns the root commit.
 
+You may also have noticed that the root commit's symbol is a different shape
+than the others: `◆` instead of `○`. That shape means the commit is
+*immutable*: `jj` will refuse to rewrite it. That makes sense for the root
+commit, which is the foundation the whole repository is built on. Right now
+it's the only immutable commit we have. Once we start sharing code, `jj` will
+also protect commits selected by its immutability policy, such as trunk and
+tags. A pushed feature commit is not necessarily immutable; we'll return to the
+exact rules when we work with remotes.
+
 One more thing: my text representation of the output of `jj log` was missing
 something. Here's a screenshot of my terminal, and you may notice something
 interesting:

--- a/src/hello-world/viewing-the-current-status.md
+++ b/src/hello-world/viewing-the-current-status.md
@@ -30,7 +30,7 @@ Working copy changes:
 A .gitignore
 A Cargo.lock
 A Cargo.toml
-A src\main.rs
+A src/main.rs
 Working copy : qzmzpxyl bc915fcd (no description set)
 Parent commit: zzzzzzzz 00000000 (empty) (no description set)
 ```
@@ -42,7 +42,7 @@ Working copy changes:
 A .gitignore
 A Cargo.lock
 A Cargo.toml
-A src\main.rs
+A src/main.rs
 ```
 
 This is the first thing we need to talk about: unlike `git`, `jj` has no index.

--- a/src/hello-world/viewing-the-current-status.md
+++ b/src/hello-world/viewing-the-current-status.md
@@ -31,8 +31,8 @@ A .gitignore
 A Cargo.lock
 A Cargo.toml
 A src/main.rs
-Working copy : qzmzpxyl bc915fcd (no description set)
-Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+Working copy  (@) : qzmzpxyl bc915fcd (no description set)
+Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
 ```
 
 There's a surprising amount of stuff to talk about here! Let's dig into it.
@@ -63,8 +63,8 @@ copy (the files on disk) and takes a snapshot. So here, it's noticed that we've
 `A`dded some new files. You'll also see `M`odified files, and `D`eleted files.
 
 ```text
-Working copy : qzmzpxyl bc915fcd (no description set)
-Parent commit: zzzzzzzz 00000000 (empty) (no description set)
+Working copy  (@) : qzmzpxyl bc915fcd (no description set)
+Parent commit (@-): zzzzzzzz 00000000 (empty) (no description set)
 ```
 
 Our brand new repo shows that we have two *changes*. You'll notice that the

--- a/src/hello-world/viewing-the-current-status.md
+++ b/src/hello-world/viewing-the-current-status.md
@@ -75,7 +75,7 @@ and that's that in `jj`, commits can evolve over time. But we still need a
 stable identifier to talk about those changes, so we have a "change ID," and
 that's `qzmzpxyl` and `zzzzzzzz`. One really cool thing is that they use a
 disjoint set of identifiers: `qzmzpxyl` can never be a commit ID, but must be
-a change ID, and `bc914fcd` can never be a change ID, but must be a commit ID.
+a change ID, and `bc915fcd` can never be a change ID, but must be a commit ID.
 This is surprisingly handy.
 
 Anyway, we'll talk more about commits and changes soon, and how they're

--- a/src/introduction/how-to-read.md
+++ b/src/introduction/how-to-read.md
@@ -52,8 +52,10 @@ to make it easier to understand. This section will show you the power of `jj`'s
 various primitive operations by some practical workflows you may decide to
 incorporate into your usage of `jj`.
 
-Additionally, we'll cover some advanced features of the tool: workspaces and
-colocated repositories. You may not use these, but it's good to know about them.
+Additionally, we'll cover two features you may never need, but should know
+exist: workspaces, which give you several working copies over one repository,
+and non-colocated repositories, which put the `git` repository backing your work
+out of other tools' reach.
 
 ## Fixing problems
 

--- a/src/real-world-workflows/absorbing-changes.md
+++ b/src/real-world-workflows/absorbing-changes.md
@@ -1,0 +1,109 @@
+# Absorbing changes with `jj absorb`
+
+We've seen that `jj squash` moves our work into one commit, while `jj split`
+breaks one commit into two. Both need us to say where the work should go.
+`jj absorb` can work that out for us.
+
+The situation it's built for turns up all the time. Let's say we have a stack
+of finished commits and, while reading over them, we spot small problems in
+several commits at once: a typo here, a rename we missed there. We fix them all
+in our working copy, and now we have one change whose pieces belong in several
+different commits.
+
+Here's a small version. Two finished commits, each having touched one file:
+
+```console
+$ jj log
+@  wmtwzxmv steve@steveklabnik.com 2024-03-26 09:14:48 e9cfed95
+│  (no description set)
+○  towkwvlp steve@steveklabnik.com 2024-03-26 09:14:48 013493d0
+│  add an evaluator
+○  wumvwlxp steve@steveklabnik.com 2024-03-26 09:14:48 8fa7ccba
+│  add a parser
+○  rlrtxyru steve@steveklabnik.com 2024-03-26 09:14:48 26dcb6b5
+│  initial
+◆  zzzzzzzz root() 00000000
+```
+
+We've gone back and touched up both of them from the working copy:
+
+```console
+$ jj st
+Working copy changes:
+M a.txt
+M b.txt
+Working copy  (@) : wmtwzxmv e9cfed95 (no description set)
+Parent commit (@-): towkwvlp 013493d0 add an evaluator
+```
+
+We could sort this out by hand with two `jj squash --into` commands and the
+right paths, or with a `jj split` followed by two rebases. Instead, let's try
+`jj absorb`:
+
+```console
+$ jj absorb
+Absorbed changes into 2 revisions:
+  towkwvlp 012a265e add an evaluator
+  wumvwlxp 4891076c add a parser
+Working copy  (@) now at: ttoyvukr 4c383532 (empty) (no description set)
+Parent commit (@-)      : towkwvlp 012a265e add an evaluator
+```
+
+Each hunk went where it belonged, the descendants were rebased, and the working
+copy is empty again:
+
+```console
+$ jj log
+@  ttoyvukr steve@steveklabnik.com 2024-03-26 09:14:48 4c383532
+│  (empty) (no description set)
+○  towkwvlp steve@steveklabnik.com 2024-03-26 09:14:48 012a265e
+│  add an evaluator
+○  wumvwlxp steve@steveklabnik.com 2024-03-26 09:14:48 4891076c
+│  add a parser
+○  rlrtxyru steve@steveklabnik.com 2024-03-26 09:14:48 26dcb6b5
+│  initial
+◆  zzzzzzzz root() 00000000
+```
+
+## How it decides
+
+For each hunk, `jj` looks at which commit last touched those lines, and puts the
+hunk there. That's the whole rule. It's the same question `git blame` answers,
+used to route your edit rather than to assign blame.
+
+This has two useful consequences:
+
+* A hunk whose lines nobody has touched has no home, so it stays in your working
+  copy. Add a brand new file and `jj absorb` will tell you `Nothing changed`.
+  Nothing gets guessed at.
+* It only writes to commits you're allowed to rewrite. Lines whose last change
+  is in an immutable commit — anything on trunk — are left where they are.
+
+So `jj absorb` moves the parts it can place confidently and leaves the rest for
+us. If the working copy still has something in it afterwards, that's the part
+we need to decide about.
+
+## Narrowing it
+
+Paths limit it to part of the tree:
+
+```console
+$ jj absorb src/
+```
+
+and `--from` / `--into` set the source and the candidate destinations
+explicitly:
+
+```console
+$ jj absorb --from @ --into 'mutable()'
+```
+
+The default source is `@`, and the default destinations are the mutable
+ancestors, which is what you want almost every time.
+
+## Where this fits
+
+`jj squash`, `jj split`, and `jj absorb` are the three commands that move work
+between commits after the fact. We can squash to combine, split to separate,
+and absorb when the destination is clear from the history. Between them, we can
+tidy up a stack before review without rebuilding it by hand.

--- a/src/real-world-workflows/editing-a-commit.md
+++ b/src/real-world-workflows/editing-a-commit.md
@@ -1,0 +1,66 @@
+# Editing a commit's diff with `jj diffedit`
+
+`jj split` pulls one change into two, and `jj squash` moves work between
+changes. Sometimes we don't want to move anything, though. We just want to fix
+what one commit *contains*: perhaps there's a stray debug line three commits
+back, or a file that shouldn't have been touched.
+
+With `git`, we might start an interactive rebase, stop at the commit, amend it,
+and continue. `jj diffedit` gives us a more direct route. It opens the commit's
+diff, lets us edit it, and writes the result back without checking out the
+commit.
+
+## Fixing a commit in place
+
+Let's point it at the revision we want to fix:
+
+```console
+$ jj diffedit -r 'description(glob:"add feature*")'
+```
+
+With the default configuration, we'll get the same TUI we saw with `jj split`
+and `jj squash -i`, showing that commit's diff. The left side is the parent, and
+the right side is the commit. We can edit the right side until it contains what
+we intended, perhaps unticking a line we didn't mean to add or deleting a debug
+statement. When we close the editor, `jj` updates the commit and rebases
+everything on top of it:
+
+```console
+$ jj diffedit -r 'description(glob:"add feature*")'
+Rebased 1 descendant commits.
+Working copy  (@) now at: pxukppkx 5f724084 (empty) (no description set)
+Parent commit (@-)      : nmvqtsqq f1b645ea add feature
+```
+
+Our working copy never moved! We didn't need to check out the commit, use
+`jj edit`, or run `jj new` afterwards. As with any rewrite, rebasing its
+descendants can introduce conflicts that we'll then need to resolve.
+
+## What you can and can't do here
+
+`jj diffedit` edits the *content* of one commit against its parent. You're
+changing what the patch does, not where it sits. For the neighboring jobs:
+
+* Moving a whole file's contents in from another revision is
+  [`jj restore`](../fixing-problems/reverting-changes.md).
+* Moving a hunk *between* two commits is `jj squash -i`.
+* Splitting one commit into two is `jj split`.
+
+That leaves `jj diffedit` for the case where one commit's diff is almost right
+and we want to fix it in place.
+
+## Comparing two revisions instead
+
+We can also use `--from` and `--to` to edit the diff between any two revisions.
+`diffedit` will write the result into the `--to` side:
+
+```console
+$ jj diffedit --from A --to B
+```
+
+The `-r` form is just the common case of this, where `--from` is the parent.
+Most of the time `-r` is what you want.
+
+Like every rewrite, editing a commit gives it a new commit ID and rebases its
+descendants, so the immutable rule applies: `jj` won't let you `diffedit` a
+commit on trunk.

--- a/src/real-world-workflows/intro.md
+++ b/src/real-world-workflows/intro.md
@@ -10,4 +10,7 @@ commands, we can have nicer workflows that let us work a bit more naturally.
 
 We'll start with the "squash workflow," as it is the workflow that Martin, the
 creator of `jj`, prefers. We'll then talk about the "edit workflow," which is
-popular among people who don't like the squash workflow.
+popular among people who don't like the squash workflow. Finally, we'll cover two
+commands you'll want whichever workflow you settle on: `jj split`, which pulls
+one change apart into two, and `jj absorb`, which files a pile of small fixes
+back into the commits they belong to.

--- a/src/real-world-workflows/intro.md
+++ b/src/real-world-workflows/intro.md
@@ -10,8 +10,8 @@ commands, we can have nicer workflows that let us work a bit more naturally.
 
 We'll start with the "squash workflow," as it is the workflow that Martin, the
 creator of `jj`, prefers. We'll then talk about the "edit workflow," which is
-popular among people who don't like the squash workflow. Finally, we'll cover two
-commands you'll want whichever workflow you settle on: `jj split`, which pulls
+popular among people who don't like the squash workflow. Finally, we'll cover
+three commands you'll want whichever workflow you settle on: `jj split`, which pulls
 one change apart into two, `jj absorb`, which files a pile of small fixes back
 into the commits they belong to, and `jj diffedit`, which reaches into a single
 commit and fixes what it contains.

--- a/src/real-world-workflows/intro.md
+++ b/src/real-world-workflows/intro.md
@@ -12,5 +12,6 @@ We'll start with the "squash workflow," as it is the workflow that Martin, the
 creator of `jj`, prefers. We'll then talk about the "edit workflow," which is
 popular among people who don't like the squash workflow. Finally, we'll cover two
 commands you'll want whichever workflow you settle on: `jj split`, which pulls
-one change apart into two, and `jj absorb`, which files a pile of small fixes
-back into the commits they belong to.
+one change apart into two, `jj absorb`, which files a pile of small fixes back
+into the commits they belong to, and `jj diffedit`, which reaches into a single
+commit and fixes what it contains.

--- a/src/real-world-workflows/splitting-changes.md
+++ b/src/real-world-workflows/splitting-changes.md
@@ -1,11 +1,11 @@
 # Splitting a change with `jj split`
 
-`jj squash` takes two changes and makes them one. Sooner or later you'll want
-to go the other way: you sat down to fix a bug, noticed some unrelated mess,
-tidied it up while you were in there, and now one change is doing two jobs. The
-reviewer is going to ask you to separate them, and they're right.
+`jj squash` takes two changes and makes them one. Sooner or later, we'll want to
+go the other way. Maybe we sat down to fix a bug, noticed something unrelated,
+tidied it up while we were there, and ended up with one change doing two jobs.
+Those jobs will be easier to understand and review if we separate them.
 
-That's `jj split`.
+That's what `jj split` is for.
 
 Here's the situation. We meant to add a function, but we wrote some
 documentation at the same time:
@@ -44,8 +44,8 @@ $ jj log --limit 3
 
 The docs went into the first change, and everything else stayed in the second.
 The second still has the old description, "two unrelated things at once", which
-is now a lie — so `jj describe` it into something honest. `jj` can split your
-change for you but it can't know what the halves should be called.
+isn't accurate any more. We should use `jj describe` to give it a better name.
+`jj` can split the change for us, but it can't know what the two parts mean.
 
 One detail worth noticing: the *selected* part kept the original change ID,
 `ynplyknw`, and the remainder got a fresh one. The part you pull out is treated
@@ -78,9 +78,9 @@ Working copy  (@) now at: uwmkvzlt f2e56704 a child commit
 Parent commit (@-)      : nkrkylxx 6f0f5589 the middle commit
 ```
 
-That change was in the middle of a stack with work on top of it, and you can
-see `jj` rebased the descendants without being asked. Same story as always: it
-just works, and your working copy didn't move.
+That change was in the middle of a stack with work on top of it, and we can see
+that `jj` rebased the descendants automatically. Just like our earlier
+rewrites, the working copy didn't move.
 
 The automatic rebase is especially useful when the change is in the middle of
 a stack. With `git`, we would usually start an interactive rebase, stop at the
@@ -103,8 +103,8 @@ you split one change into two pull requests that don't depend on each other.
 
 ## Where this fits
 
-Between `jj squash` and `jj split` you can push work in either direction: merge
-changes together, break them apart, and move pieces between them. Add `jj absorb`
-from a couple of chapters ago, which shoves each hunk into whichever ancestor
-already touched those lines, and rearranging history stops feeling like surgery
-and starts feeling like editing.
+Between `jj squash` and `jj split`, we can move work in either direction: merge
+changes together, break them apart, and move pieces between them. The next
+chapter adds `jj absorb`, which places each hunk into whichever ancestor already
+touched those lines. Together, these commands make rearranging history feel a
+lot more like ordinary editing.

--- a/src/real-world-workflows/splitting-changes.md
+++ b/src/real-world-workflows/splitting-changes.md
@@ -1,0 +1,110 @@
+# Splitting a change with `jj split`
+
+`jj squash` takes two changes and makes them one. Sooner or later you'll want
+to go the other way: you sat down to fix a bug, noticed some unrelated mess,
+tidied it up while you were in there, and now one change is doing two jobs. The
+reviewer is going to ask you to separate them, and they're right.
+
+That's `jj split`.
+
+Here's the situation. We meant to add a function, but we wrote some
+documentation at the same time:
+
+```console
+$ jj st
+Working copy changes:
+A DOCS.md
+A main.rs
+Working copy  (@) : ynplyknw dce433ae two unrelated things at once
+Parent commit (@-): mllnrzow 4d1201b4 initial
+```
+
+Two files, two unrelated jobs, one change. Let's pull the docs out:
+
+```console
+$ jj split DOCS.md -m "add some docs"
+Selected changes : ynplyknw cd1826ed add some docs
+Remaining changes: mxvnxuyl 618910f4 two unrelated things at once
+Working copy  (@) now at: mxvnxuyl 618910f4 two unrelated things at once
+Parent commit (@-)      : ynplyknw cd1826ed add some docs
+```
+
+We named the paths we wanted to peel off, and `-m` gave the new change its
+description. Now there are two:
+
+```console
+$ jj log --limit 3
+@  mxvnxuyl steve@steveklabnik.com 2024-03-20 11:44:17 618910f4
+│  two unrelated things at once
+○  ynplyknw steve@steveklabnik.com 2024-03-20 11:44:17 cd1826ed
+│  add some docs
+○  mllnrzow steve@steveklabnik.com 2024-03-20 11:43:36 4d1201b4
+│  initial
+```
+
+The docs went into the first change, and everything else stayed in the second.
+The second still has the old description, "two unrelated things at once", which
+is now a lie — so `jj describe` it into something honest. `jj` can split your
+change for you but it can't know what the halves should be called.
+
+One detail worth noticing: the *selected* part kept the original change ID,
+`ynplyknw`, and the remainder got a fresh one. The part you pull out is treated
+as the continuation of the original change.
+
+## Splitting interactively
+
+Naming paths works when the split falls on file boundaries. Often it doesn't —
+two changes tangled in the same file. Leave off the paths:
+
+```console
+$ jj split
+```
+
+and you get the same TUI we saw with `jj squash -i`, where you pick individual
+hunks and lines. Everything you select goes into the first change, everything
+you don't goes into the second. `jj split -i` does the same thing while still
+letting you narrow to some paths first.
+
+## Splitting something other than the working copy
+
+Everything so far has split `@`. Use `-r` for any other change:
+
+```console
+$ jj split -r mxvnxuyl extra.txt -m "just the extra file"
+Rebased 1 descendant commits.
+Selected changes : mxvnxuyl 14798ea1 just the extra file
+Remaining changes: nkrkylxx 6f0f5589 the middle commit
+Working copy  (@) now at: uwmkvzlt f2e56704 a child commit
+Parent commit (@-)      : nkrkylxx 6f0f5589 the middle commit
+```
+
+That change was in the middle of a stack with work on top of it, and you can
+see `jj` rebased the descendants without being asked. Same story as always: it
+just works, and your working copy didn't move.
+
+The automatic rebase is especially useful when the change is in the middle of
+a stack. With `git`, we would usually start an interactive rebase, stop at the
+commit, separate its contents, and then continue the rebase. Here we can name
+any commit we're still allowed to rewrite, and `jj split` takes care of its
+descendants for us.
+
+## Two children instead of a parent and a child
+
+By default the halves end up stacked, one on top of the other. If they're
+genuinely independent, `-p` makes them siblings instead:
+
+```console
+$ jj split -p DOCS.md -m "add some docs"
+```
+
+Now you have two changes side by side, both on the original parent — an
+anonymous branch, of the sort we made back in the branching chapter. Handy when
+you split one change into two pull requests that don't depend on each other.
+
+## Where this fits
+
+Between `jj squash` and `jj split` you can push work in either direction: merge
+changes together, break them apart, and move pieces between them. Add `jj absorb`
+from a couple of chapters ago, which shoves each hunk into whichever ancestor
+already touched those lines, and rearranging history stops feeling like surgery
+and starts feeling like editing.

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -54,8 +54,9 @@ When we begin more work we start it with `jj new -m ""` and get to work.
 But sometimes, when we're working on something, we realize we also want a
 different change, and maybe it relies on this one. For example, let's say that
 we were working on undoing this goodbye feature, but we realized we wanted
-to refactor printing out into its own function, because that's a terrible idea
-in practice and so makes for a good example to play around with.
+to add some more comments first, because over-commenting a five-line program
+is a terrible idea in practice and so makes for a good example to play around
+with.
 
 What we want to do is make a new change before this one. So let's do that.
 
@@ -173,7 +174,7 @@ simpler command:
 ```console
 $ jj next --edit
 Working copy  (@) now at: ootnlvpt e13b2585 only print hello world
-Parent commit (@-)      : nmptruqn 90a2e97f refactor printing
+Parent commit (@-)      : nmptruqn 90a2e97f add more comments
 Added 0 files, modified 1 files, removed 0 files
 ```
 

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -32,8 +32,8 @@ But since we have an empty change, what we'll actually do is:
 
 ```console
 > jj describe -m "only print hello world"
-Working copy now at: ootnlvpt bb06f041 (empty) only print hello world
-Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) now at: ootnlvpt bb06f041 (empty) only print hello world
+Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 ```
 
 We are now ready to do some work.
@@ -66,8 +66,8 @@ Let's try this:
 ```console
 $ jj new -B @ -m "add more comments"
 Rebased 1 descendant commits
-Working copy now at: nmptruqn 30a1f33b (empty) add more comments
-Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) now at: nmptruqn 30a1f33b (empty) add more comments
+Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -144,8 +144,8 @@ $ jj st
 Rebased 1 descendant commits onto updated working copy
 Working copy changes:
 M src/main.rs
-Working copy : nmptruqn 90a2e97f add more comments
-Parent commit: ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) : nmptruqn 90a2e97f add more comments
+Parent commit (@-): ywnkulko ed71bb54 print goodbye as well as hello
 ```
 
 Yet again, a rebase. Because we have changed the contents of our change,
@@ -172,8 +172,8 @@ simpler command:
 
 ```console
 $ jj next --edit
-Working copy now at: ootnlvpt e13b2585 only print hello world
-Parent commit      : nmptruqn 90a2e97f refactor printing
+Working copy  (@) now at: ootnlvpt e13b2585 only print hello world
+Parent commit (@-)      : nmptruqn 90a2e97f refactor printing
 Added 0 files, modified 1 files, removed 0 files
 ```
 

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -65,7 +65,7 @@ Let's try this:
 
 ```console
 $ jj new -B @ -m "add more comments"
-Rebased 1 descendant commits
+Rebased 1 descendant commits.
 Working copy  (@) now at: nmptruqn 30a1f33b (empty) add more comments
 Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 Added 0 files, modified 1 files, removed 0 files
@@ -77,7 +77,7 @@ We have a new flag to `jj new`, `-B`. This says to create the new change
 The first line of the output should raise some eyebrows:
 
 ```text
-Rebased 1 descendant commits
+Rebased 1 descendant commits.
 ```
 
 That's right, because we have created a change before the one we're on, it
@@ -141,7 +141,7 @@ This is very silly. Regardless, we have finished. Let's see our current status:
 
 ```console
 $ jj st
-Rebased 1 descendant commits onto updated working copy
+Rebased 1 descendant commits onto updated working copy.
 Working copy changes:
 M src/main.rs
 Working copy  (@) : nmptruqn 90a2e97f add more comments

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -143,7 +143,7 @@ This is very silly. Regardless, we have finished. Let's see our current status:
 $ jj st
 Rebased 1 descendant commits onto updated working copy
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : nmptruqn 90a2e97f add more comments
 Parent commit: ywnkulko ed71bb54 print goodbye as well as hello
 ```

--- a/src/real-world-workflows/the-edit-workflow.md
+++ b/src/real-world-workflows/the-edit-workflow.md
@@ -91,17 +91,17 @@ In the meantime, let's examine our log:
 
 ```console
 $ jj log
-◉  ootnlvpt steve@steveklabnik.com 2024-02-28 22:59:46.000 -06:00 be40656e
+○  ootnlvpt steve@steveklabnik.com 2024-02-28 22:59:46 be40656e
 │  only print hello world
-@  nmptruqn steve@steveklabnik.com 2024-02-28 22:59:46.000 -06:00 30a1f33b
+@  nmptruqn steve@steveklabnik.com 2024-02-28 22:59:46 30a1f33b
 │  (empty) add more comments
-◉  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40.000 -06:00 ed71bb54
+○  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40 ed71bb54
 │  print goodbye as well as hello
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 We can see that `@` is at our new empty change, and that we have our original
@@ -186,17 +186,17 @@ Let's double check with `jj log`:
 
 ```console
 $ jj log
-@  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44.000 -06:00 b5db7940
+@  ootnlvpt steve@steveklabnik.com 2024-02-28 23:26:44 b5db7940
 │  only print hello world
-◉  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11.000 -06:00 90a2e97f
+○  nmptruqn steve@steveklabnik.com 2024-02-28 23:09:11 90a2e97f
 │  add more comments
-◉  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40.000 -06:00 ed71bb54
+○  ywnkulko steve@steveklabnik.com 2024-02-28 22:09:40 ed71bb54
 │  print goodbye as well as hello
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 That's correct, `@` is at our original change.

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -142,7 +142,8 @@ the stuff in `@` with `jj abandon`:
 
 ```console
 $ jj abandon
-Abandoned commit oopolqyp 44665581 (no description set)
+Abandoned 1 commits:
+  oopolqyp 44665581 (no description set)
 Working copy  (@) now at: ootnlvpt 97b7a559 (empty) (no description set)
 Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 Added 0 files, modified 1 files, removed 0 files

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -37,8 +37,8 @@ Let's describe the work that we want to do:
 
 ```console
 $ jj describe -m "print goodbye as well as hello"
-Working copy now at: ywnkulko 4bfe3940 (empty) print goodbye as well as hello
-Parent commit      : puomrwxl 7a096b8a it's important to comment our code
+Working copy  (@) now at: ywnkulko 4bfe3940 (empty) print goodbye as well as hello
+Parent commit (@-)      : puomrwxl 7a096b8a it's important to comment our code
 ```
 
 This change is currently empty, but we've now given it a useful name. This
@@ -51,8 +51,8 @@ our commit or not. So let's make a new one:
 
 ```console
 $ jj new
-Working copy now at: rkvxolny 5e020e00 (empty) (no description set)
-Parent commit      : ywnkulko 4bfe3940 (empty) print goodbye as well as hello
+Working copy  (@) now at: rkvxolny 5e020e00 (empty) (no description set)
+Parent commit (@-)      : ywnkulko 4bfe3940 (empty) print goodbye as well as hello
 ```
 
 We now have our change. It's also empty! There's no issue having two empty
@@ -81,8 +81,8 @@ Now that our "feature" has been implemented, let's see our current changes:
 $ jj st
 Working copy changes:
 M src/main.rs
-Working copy : rkvxolny aee5266d (no description set)
-Parent commit: ywnkulko 4bfe3940 (empty) print goodbye as well as hello
+Working copy  (@) : rkvxolny aee5266d (no description set)
+Parent commit (@-): ywnkulko 4bfe3940 (empty) print goodbye as well as hello
 ```
 
 We now have an even wilder situation than before: our current change has stuff
@@ -92,8 +92,8 @@ from our "staging area" and put it into our commit (change). We can do that with
 
 ```console
 $ jj squash
-Working copy now at: oopolqyp 9fb63b14 (empty) (no description set)
-Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) now at: oopolqyp 9fb63b14 (empty) (no description set)
+Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 ```
 
 Lots of changes here! `@` is now empty, with no description, and the parent is
@@ -143,8 +143,8 @@ the stuff in `@` with `jj abandon`:
 ```console
 $ jj abandon
 Abandoned commit oopolqyp 44665581 (no description set)
-Working copy now at: ootnlvpt 97b7a559 (empty) (no description set)
-Parent commit      : ywnkulko ed71bb54 print goodbye as well as hello
+Working copy  (@) now at: ootnlvpt 97b7a559 (empty) (no description set)
+Parent commit (@-)      : ywnkulko ed71bb54 print goodbye as well as hello
 Added 0 files, modified 1 files, removed 0 files
 ```
 

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -152,6 +152,14 @@ Added 0 files, modified 1 files, removed 0 files
 We've thrown away `oopolqyp`, and `jj` has helpfully made a new empty change
 for us. 
 
+One little surprise to warn you about before it happens to you. In this
+workflow, our scratch change never has a description, so `jj squash` quietly
+merges it into its parent. If the change you're squashing *does* have a
+description — and so does the destination — `jj` doesn't want to guess which
+one to keep, so it pops open your editor with both, for you to combine. You
+can skip the editor by passing `-m` for a new message, or `-u` to just keep
+the destination's.
+
 This is the kind of stuff I mean when I say "the same power, but less concepts."
 We've got the tools that the index gave us, but they're simpler because we don't
 use some of them on the index, and some on commits: we use them all on commits.

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -80,7 +80,7 @@ Now that our "feature" has been implemented, let's see our current changes:
 ```console
 $ jj st
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : rkvxolny aee5266d (no description set)
 Parent commit: ywnkulko 4bfe3940 (empty) print goodbye as well as hello
 ```

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -24,13 +24,13 @@ Let's recap where we are in our project: `@` currently is an empty commit:
 
 ```console
 > jj log
-@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00.000 -06:00 46b50ed7
+@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00 46b50ed7
 │  (empty) (no description set)
-◉  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13.000 -06:00 7a096b8a
+○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code
-◉  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56.000 -06:00 ac691d85
+○  yyrsmnoo steve@steveklabnik.com 2024-02-28 20:24:56 ac691d85
 │  hello world
-◉  zzzzzzzz root() 00000000
+◆  zzzzzzzz root() 00000000
 ```
 
 Let's describe the work that we want to do:

--- a/src/real-world-workflows/the-squash-workflow.md
+++ b/src/real-world-workflows/the-squash-workflow.md
@@ -24,7 +24,7 @@ Let's recap where we are in our project: `@` currently is an empty commit:
 
 ```console
 > jj log
-@  ywnkulko steve@steveklabnik.com 2024-02-28 20:40:00 46b50ed7
+@  ywnkulko steve@steveklabnik.com 2024-02-28 21:12:07 b7de0217
 │  (empty) (no description set)
 ○  puomrwxl steve@steveklabnik.com 2024-02-28 20:38:13 7a096b8a
 │  it's important to comment our code

--- a/src/sharing-code/forks.md
+++ b/src/sharing-code/forks.md
@@ -1,0 +1,80 @@
+# Working with a fork
+
+When we contribute to a project we can't push to directly, we usually have two
+remotes: we fetch from the project's repository and push to our own fork. `jj`
+handles this much like `git`, but there are a couple of details worth knowing.
+
+Let's add the project's repository as our second remote:
+
+```console
+$ jj git remote add upstream https://github.com/someone/theproject.git
+
+$ jj git remote list
+origin https://github.com/steveklabnik/theproject.git
+upstream https://github.com/someone/theproject.git
+```
+
+By convention `origin` is your fork, the one you can push to, and `upstream` is
+the real project. `jj` attaches no meaning to either name.
+
+## Fetching from both
+
+```console
+$ jj git fetch --remote upstream
+bookmark: main@upstream [new] untracked
+```
+
+Notice the word `untracked`. A bookmark from a remote we added by hand doesn't
+become one of our local bookmarks. We get `main@upstream`, which we can refer
+to, but no local `main` follows it around.
+
+That's usually right for a fork. You don't want your local `main` chasing two
+different remotes. Refer to `main@upstream` explicitly when you want it:
+
+```console
+$ jj rebase -b @ -o main@upstream
+```
+
+It also means the upstream bookmark is immutable, since the default immutable
+set includes `untracked_remote_bookmarks()`. You can't accidentally rewrite the
+project's history, which is a reasonable default when it isn't yours.
+
+If you do want a local bookmark following it:
+
+```console
+$ jj bookmark track main@upstream
+Started tracking 1 remote bookmarks.
+```
+
+and `jj bookmark untrack main@upstream` undoes that.
+
+`--all-remotes` fetches from everything at once, and `jj bookmark list
+--all-remotes` shows you where each name sits on each remote:
+
+```console
+$ jj bookmark list --all-remotes
+main: oqtwrqnv 07effb17 (empty) local commit on main
+  @git: oqtwrqnv 07effb17 (empty) local commit on main
+  @origin (behind by 1 commits): quvlnmky edd53bde upstream commit 2
+main@upstream: quvlnmky edd53bde upstream commit 2
+my-feature: tqmvurqz 71ade80c my feature
+```
+
+## Fetching from one, pushing to the other
+
+Typing `--remote` every time gets old, so let's set the defaults for this
+repository:
+
+```console
+$ jj config set --repo git.fetch upstream
+$ jj config set --repo git.push origin
+```
+
+Now a bare `jj git fetch` reads from the project and a bare `jj git push` writes
+to your fork, which is the fork workflow in two settings. Because we used
+`--repo`, this applies to this checkout only, and it lives in your own config
+directory rather than in the repository, so there's nothing to accidentally
+commit.
+
+The rest is what we already know. We can rebase onto `main@upstream` to catch
+up, push a bookmark to our fork, and open the pull request from there.

--- a/src/sharing-code/gerrit.md
+++ b/src/sharing-code/gerrit.md
@@ -1,42 +1,68 @@
-# Working with Gerrit
+# Using `jj` with Gerrit
 
-The Gerrit-based workflow prefers small commits that get reviewed individually,
-as "changelists" (CLs). `jj` is well suited for this workflow: each `jj` change
-can be a single CL which you can update over time. Each new update to a change
-is tracked as a new patchset, this will allow you to see how a
-change evolved over time directly in the UI.
+Everything in this section so far has assumed GitHub, or something shaped like
+it: branches, pull requests, one review per branch. Gerrit is the other major
+shape of code review, and it turns out `jj` fits it remarkably well — arguably
+better than `git` does.
 
-## Change IDs
+In Gerrit, the unit of review isn't a branch, it's a single commit, called a
+"change" (or a "CL"). You upload a commit, a reviewer comments on it, you
+rewrite the commit and upload it again, and Gerrit shows each uploaded version
+as a numbered "patch set" on the same change. If that sounds familiar, it
+should: it's exactly how we've been treating `jj` changes all along. One `jj`
+change becomes one Gerrit change, and rewriting it — with `jj squash`,
+`jj absorb`, `jj describe`, whatever we like — produces its next patch set.
 
-Similar to `jj`'s change IDs, Gerrit associates commits with a common "change"
-using a `Change-Id` footer in the commits. When using the `jj gerrit upload`
-command, the footer is added automatically to all commits in the revset that
-don't already have one.
+## Change IDs, twice over
 
-## Push workflow
+Gerrit needs a way to recognize that a rewritten commit is a new version of an
+existing change, and its answer predates `jj`: a `Change-Id:` trailer in the
+commit message. That's the same problem `jj`'s change IDs solve, but they are
+two different identifiers. When we upload, `jj` adds the trailer for us,
+deriving it from the `jj` change ID, and leaves any existing trailer alone. We
+don't need to manage it, but don't be surprised to see it in our descriptions
+afterwards.
 
-In a traditional Gerrit workflow, you push commits to the review server using
-`git push origin <rev>:refs/for/main`.
+## Uploading
 
-JJ support this workflow natively thanks to the `jj gerrit upload` command.
-With this command you can upload revsets to Gerrit directly, if a JJ change is
-missing the change-id footer, the command will add it automatically. You can
-also modify the footer manually if you wish to associate a specific JJ change
-with an already existing Gerrit change.
+In a traditional Gerrit workflow, you push with a magic refspec:
+`git push origin HEAD:refs/for/main`. `jj` wraps this up in a single command:
 
-If you want to triple check which commits will be modified and pushed with this
-command you can run `jj gerrit upload -r <revset> --remote-branch <branch-name> --dry-run`
+```console
+$ jj gerrit upload -r 'trunk()..@' --remote-branch main
+```
 
-### Remote branch selection
+The `-r` revset selects what to upload — here, our whole stack — and
+`--remote-branch` names the branch the changes are intended to land on. Each
+revision in the revset becomes its own Gerrit change, so uploading a stack of
+three commits opens three changes, each reviewable on its own, with their
+relationships intact. This is the "stacked" workflow that takes real effort on
+GitHub, and on Gerrit it's just how things work.
 
-When using `jj gerrit upload` you can either have a default remote branch
-selected or overwrite it with each upload.
+Because uploading may *rewrite* our commits — adding missing `Change-Id`
+trailers — as well as push them, I like to dry-run a broad revset before
+running it for real:
 
-To configure a default remote branch please run:
-`jj config set --user gerrit.default-remote-branch <branch name>`
+```console
+$ jj gerrit upload -r 'trunk()..@' --remote-branch main --dry-run
+```
 
-while if you want to change it for a specific push you can do:
-`jj gerrit upload -r <revset> --remote-branch <branch-name>`
+Responding to review is the part that should feel comfortable by now: edit the
+change like any other — `jj edit`, or fix things in `@` and `jj squash` or
+`jj absorb` them down — and upload again. The stable trailer tells Gerrit it's
+the same change, and the reviewer sees a new patch set, with Gerrit's UI able
+to diff one patch set against another. There's no branch to force-push and no
+bookmark to move.
 
+## A default branch
 
+Typing `--remote-branch main` every time gets old. We can set a default for
+the repository:
 
+```console
+$ jj config set --repo gerrit.default-remote-branch main
+```
+
+After that, `jj gerrit upload -r 'trunk()..@'` is all we need. There's a
+matching `gerrit.default-remote` setting for pointing at the Gerrit instance
+itself, if the remote isn't where we usually push.

--- a/src/sharing-code/intro.md
+++ b/src/sharing-code/intro.md
@@ -12,4 +12,5 @@ Here's what we're going to learn:
 * Adding commits to a pull request
 * Marking a release with tags
 * Catching up when other people move trunk underneath you
+* Contributing through a fork, with two remotes
 * How to use `jj` with Gerrit rather than GitHub

--- a/src/sharing-code/intro.md
+++ b/src/sharing-code/intro.md
@@ -10,4 +10,6 @@ Here's what we're going to learn:
 * Using named branches in `jj`
 * Working with remotes, e.g., GitHub
 * Adding commits to a pull request
+* Marking a release with tags
+* Catching up when other people move trunk underneath you
 * How to use `jj` with Gerrit rather than GitHub

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -37,8 +37,8 @@ new change:
 
 ```console
 > jj new
-Working copy now at: pzkrzopz 3f14c03f (empty) (no description set)
-Parent commit      : povouosx 7ec11c41 trunk | remove goodbye message
+Working copy  (@) now at: pzkrzopz 3f14c03f (empty) (no description set)
+Parent commit (@-)      : povouosx 7ec11c41 trunk | remove goodbye message
 > jj log
 @  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 fcf669c5
 │  (empty) (no description set)

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -11,9 +11,9 @@ To create a named branch (bookmark) in `jj`, we can use `jj bookmark create`:
 ```console
 $ jj bookmark create trunk
 $ jj log --limit 2
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
 ```
 
@@ -24,9 +24,9 @@ revision or use it in a revset if we'd like:
 
 ```console
 > jj log -r 'ancestors(trunk, 2)'
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
 ~
 ```
@@ -40,11 +40,11 @@ new change:
 Working copy  (@) now at: pzkrzopz 3f14c03f (empty) (no description set)
 Parent commit (@-)      : povouosx 7ec11c41 trunk | remove goodbye message
 > jj log
-@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 fcf669c5
+@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 fcf669c5
 │  (empty) (no description set)
-│ ◉  qtlkpytx steve@steveklabnik.com 2024-03-01 20:09:25.000 -06:00 e6667f9e
+│ ○  qtlkpytx steve@steveklabnik.com 2024-03-01 20:09:25 e6667f9e
 ├─╯  (empty) (no description set)
-◉  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+○  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
 ```
 
@@ -55,11 +55,11 @@ let's forget about it:
 > jj abandon qt
 Abandoned commit qtlkpytx e6667f9e (empty) (no description set)
 > jj log --limit 3
-@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 fcf669c5
+@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 fcf669c5
 │  (empty) (no description set)
-◉  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+○  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
 ```
 
@@ -73,9 +73,9 @@ Regardless, let's update `trunk` to point at `@`:
 $ jj bookmark set trunk
 Moved 1 bookmarks to pzkrzopz fcf669c5 trunk | (empty) (no description set)
 $ jj log --limit 2
-@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 trunk fcf669c5
+@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 trunk fcf669c5
 │  (empty) (no description set)
-◉  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
+○  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
 ```
 

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -53,7 +53,8 @@ let's forget about it:
 
 ```console
 > jj abandon qt
-Abandoned commit qtlkpytx e6667f9e (empty) (no description set)
+Abandoned 1 commits:
+  qtlkpytx e6667f9e (empty) (no description set)
 > jj log --limit 3
 @  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 fcf669c5
 │  (empty) (no description set)

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -39,7 +39,7 @@ new change:
 ```console
 > jj new
 Working copy  (@) now at: pzkrzopz 3f14c03f (empty) (no description set)
-Parent commit (@-)      : povouosx 7ec11c41 trunk | remove goodbye message
+Parent commit (@-)      : povouosx f68d1623 trunk | remove goodbye message
 > jj log
 @  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 fcf669c5
 │  (empty) (no description set)

--- a/src/sharing-code/named-branches.md
+++ b/src/sharing-code/named-branches.md
@@ -10,6 +10,7 @@ To create a named branch (bookmark) in `jj`, we can use `jj bookmark create`:
 
 ```console
 $ jj bookmark create trunk
+Created 1 bookmarks pointing to povouosx f68d1623 trunk | remove goodbye message
 $ jj log --limit 2
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -19,6 +19,15 @@ and makes a `jj` repository from it. Like `jj git init`, it gives you a
 colocated repository — a `.jj` directory and a working `.git` one — so `gh` and
 anything else that reads `.git` keep working in a clone too.
 
+You may have noticed we've been talking about change IDs as if they were
+permanent, and they usually are, even across a clone. `jj` writes each change
+ID into a small header on the underlying git commit, so a plain `git clone`
+carries it along too, not just `jj git clone` — and it survives any number of
+repeated clones, pure `git` included, as long as none of them rewrite the
+commit. The one thing that loses it is rewriting the commit along the way, say
+with `git rebase` or a squash-merge on GitHub, since that header isn't part of
+git's own data model.
+
 Before we push our commit up, we need to fix our repository:
 
 ```console

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -49,13 +49,18 @@ issues with doing this.
 
 Anyway, let's push `trunk` up to GitHub. A bare `jj git push` won't do it:
 `jj` refuses to create a bookmark on the remote that it doesn't already know
-about, so we have to name it explicitly with `-b`:
+about, so we have to name it explicitly with `-b`. We can use `--dry-run` to
+inspect that push before performing it:
 
 ```console
 $ jj git push
 Warning: Refusing to create new remote bookmark trunk@origin
 Hint: Run `jj bookmark track trunk@origin` and try again.
 Nothing changed.
+$ jj git push --dry-run -b trunk
+Changes to push to origin:
+  bookmark: trunk [add to f68d16233bdc]
+Dry-run requested, not pushing.
 $ jj git push -b trunk
 Changes to push to origin:
   bookmark: trunk [add to f68d16233bdc]
@@ -66,6 +71,72 @@ Parent commit (@-)      : povouosx f68d1623 trunk | remove goodbye message
 
 Once the bookmark exists on the remote and is tracked, a bare `jj git push` is
 enough for subsequent pushes.
+
+That warning in the middle deserves a word. Remember those `◆` symbols from
+back when we first looked at `jj log`? Pushing `trunk` just created some more
+of them:
+
+```console
+$ jj log
+@  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00 f853107d
+│  (empty) (no description set)
+◆  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
+│  remove goodbye message
+~
+```
+
+Two things happened. `trunk` turned into a `◆`, and everything below it
+vanished behind a `~`. That's not `--limit` doing it. With no `-r`, `jj log`
+uses this revset:
+
+```text
+present(@) | ancestors(immutable_heads().., 2) | trunk()
+```
+
+Which is to say: the working copy, whatever's stacked above the immutable
+commits, and trunk. History you can't rewrite doesn't get drawn, on the theory
+that it's rarely what you're looking at. Ask for it explicitly and it's all
+still there:
+
+```console
+$ jj log -r '::@'
+@  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00 f853107d
+│  (empty) (no description set)
+◆  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
+│  remove goodbye message
+◆  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
+│  refactor printing
+◆  yykpmnuq steve@steveklabnik.com 2024-03-01 17:07:36 2b93da0c
+│  (empty) add better documentation
+```
+
+`trunk` and everything behind it are now immutable. The idea is simple: other
+people can see this history now, so rewriting it would be antisocial. `jj`
+enforces that for you rather than trusting you to remember:
+
+```console
+$ jj describe trunk -m "let's rewrite some shared history"
+Error: Commit f68d16233bdc is immutable
+Hint: Could not modify commit: povouosx f68d1623 trunk | remove goodbye message
+Hint: Immutable commits are used to protect shared history.
+Hint: For more information, see:
+      - https://docs.jj-vcs.dev/latest/config/#set-of-immutable-commits
+      - `jj help -k config`, "Set of immutable commits"
+Hint: This operation would rewrite 1 immutable commits.
+```
+
+This is also why we got that warning during the push. Our working copy was
+sitting *on* `povouosx`, and `povouosx` had just become immutable, so `jj`
+moved us up to a fresh change on top of it. It didn't ask, because there's no
+sensible alternative: you can't keep editing a commit you're no longer allowed
+to edit.
+
+By default the immutable set is `trunk()`, any tags, and any remote bookmarks
+you're not tracking. It's a configuration setting, not a law of nature; if you
+really do need to rewrite shared history, you can adjust
+`revset-aliases."immutable_heads()"` or pass `--ignore-immutable`. But the
+default is a good default, and I'd leave it alone until you have a specific
+reason not to.
 
 And now our project is up on GitHub!
 
@@ -192,4 +263,3 @@ push = "myfork"
 
 This can either go in the repo-specific `.jj/repo/config.toml` or the global
 config if you expect most of your repos to have the same remotes.
-

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -28,8 +28,8 @@ do that like this:
 
 ```console
 $ jj edit @-
-Working copy now at: povouosx f68d1623 remove goodbye message
-Parent commit      : vvmrvwuz d41c079b refactor printing
+Working copy  (@) now at: povouosx f68d1623 remove goodbye message
+Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 $ jj bookmark set trunk --allow-backwards
 Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
 $ jj abandon pzkrzopz
@@ -53,8 +53,8 @@ $ jj git push
 Changes to push to origin:
   Add bookmark trunk to f68d16233bdc
 Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
-Working copy now at: znurnwmk f853107d (empty) (no description set)
-Parent commit      : povouosx f68d1623 | remove goodbye message
+Working copy  (@) now at: znurnwmk f853107d (empty) (no description set)
+Parent commit (@-)      : povouosx f68d1623 | remove goodbye message
 ```
 
 And now our project is up on GitHub!
@@ -96,8 +96,8 @@ Let's fix that:
 
 ```console
 $ jj new trunk
-Working copy now at: vmunwxsk be917d2e (empty) (no description set)
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: vmunwxsk be917d2e (empty) (no description set)
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -134,8 +134,8 @@ Then let's add a description, and push our change to GitHub so we can make a PR:
 
 ```console
 $ jj describe -m "add a comment to main"
-Working copy now at: vmunwxsk 9410db49 add a comment to main
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: vmunwxsk 9410db49 add a comment to main
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 $ jj git push -c @
 Creating bookmark push-vmunwxsksqvk for revision vmunwxsksqvk
 Changes to push to origin:

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -91,7 +91,7 @@ bookmark: trunk@origin [updated] tracked
 $ jj log --limit 3
 ◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
-│ @  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00.000 f853107d
+│ @  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00 f853107d
 ├─╯  (empty) (no description set)
 ◆  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -33,7 +33,8 @@ Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 $ jj bookmark set trunk --allow-backwards
 Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
 $ jj abandon pzkrzopz
-Abandoned commit pzkrzopz fcf669c5 (empty) (no description set)
+Abandoned 1 commits:
+  pzkrzopz fcf669c5 (empty) (no description set)
 $ jj log --limit 2
 @  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -13,6 +13,12 @@ as an upstream like this:
 > jj git remote add origin git@github.com:steveklabnik/jj-hello-world.git
 ```
 
+That's the direction we need here, because our repository already exists. Going
+the other way, `jj git clone <url>` takes a project that's already on a server
+and makes a `jj` repository from it. Like `jj git init`, it gives you a
+colocated repository — a `.jj` directory and a working `.git` one — so `gh` and
+anything else that reads `.git` keep working in a clone too.
+
 Before we push our commit up, we need to fix our repository:
 
 ```console

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -258,8 +258,8 @@ review comments in the next section.
 By default, `jj git push` will push to `origin`, requiring `--remote myfork`
 to push to a fork.
 
-If you wish to push to your fork by default, you can add this line of
-configuration:
+If you wish to push to your fork by default, you can configure it. `git.fetch`
+takes several remotes, `git.push` takes one:
 
 ```toml
 [git]
@@ -267,5 +267,9 @@ fetch = ["origin", "myfork"]
 push = "myfork"
 ```
 
-This can either go in the repo-specific `.jj/repo/config.toml` or the global
-config if you expect most of your repos to have the same remotes.
+Use `--repo` to set this for one repository, or `--user` if you expect most of
+your repositories to have the same remotes. `jj config path --repo` will tell
+you where the repository's own config file lives.
+
+There's more to say about two remotes, and we'll say it in the chapter on
+working with a fork.

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -31,7 +31,7 @@ $ jj edit @-
 Working copy  (@) now at: povouosx f68d1623 remove goodbye message
 Parent commit (@-)      : vvmrvwuz d41c079b refactor printing
 $ jj bookmark set trunk --allow-backwards
-Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
+Moved 1 bookmarks to povouosx f68d1623 trunk | remove goodbye message
 $ jj abandon pzkrzopz
 Abandoned 1 commits:
   pzkrzopz fcf669c5 (empty) (no description set)
@@ -47,16 +47,25 @@ commit because it is a dangerous operation: if we had pushed `trunk`, things
 would get weird when we try and push now. We've kept it all local, so there's no
 issues with doing this.
 
-Anyway, let's push `trunk` up to GitHub:
+Anyway, let's push `trunk` up to GitHub. A bare `jj git push` won't do it:
+`jj` refuses to create a bookmark on the remote that it doesn't already know
+about, so we have to name it explicitly with `-b`:
 
 ```console
 $ jj git push
+Warning: Refusing to create new remote bookmark trunk@origin
+Hint: Run `jj bookmark track trunk@origin` and try again.
+Nothing changed.
+$ jj git push -b trunk
 Changes to push to origin:
-  Add bookmark trunk to f68d16233bdc
-Warning: The working-copy commit in workspace 'default' became immutable, so a new commit has been created on top of it.
+  bookmark: trunk [add to f68d16233bdc]
+Warning: The working-copy commit became immutable; a new commit has been created on top of it.
 Working copy  (@) now at: znurnwmk f853107d (empty) (no description set)
-Parent commit (@-)      : povouosx f68d1623 | remove goodbye message
+Parent commit (@-)      : povouosx f68d1623 trunk | remove goodbye message
 ```
+
+Once the bookmark exists on the remote and is tracked, a bare `jj git push` is
+enough for subsequent pushes.
 
 And now our project is up on GitHub!
 
@@ -140,7 +149,7 @@ Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 $ jj git push -c @
 Creating bookmark push-vmunwxsksqvk for revision vmunwxsksqvk
 Changes to push to origin:
-  Add bookmark push-vmunwxsksqvk to 9410db49f9ba
+  bookmark: push-vmunwxsksqvk [add to 9410db49f9ba]
 $ jj log
 @  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk 9410db49
 │  add a comment to main

--- a/src/sharing-code/remotes.md
+++ b/src/sharing-code/remotes.md
@@ -17,9 +17,9 @@ Before we push our commit up, we need to fix our repository:
 
 ```console
 $ jj log --limit 2
-@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37.000 -06:00 trunk fcf669c5
+@  pzkrzopz steve@steveklabnik.com 2024-03-01 22:41:37 trunk fcf669c5
 │  (empty) (no description set)
-◉  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
+○  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
 ```
 
@@ -35,9 +35,9 @@ Moved 1 bookmarks to povouosx f68d1623 | remove goodbye message
 $ jj abandon pzkrzopz
 Abandoned commit pzkrzopz fcf669c5 (empty) (no description set)
 $ jj log --limit 2
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 trunk f68d1623
+@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 trunk f68d1623
 │  remove goodbye message
-◉  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07.000 -06:00 d41c079b
+○  vvmrvwuz steve@steveklabnik.com 2024-03-01 17:49:07 d41c079b
 │  refactor printing
 ```
 
@@ -79,11 +79,11 @@ Let's fetch those changes:
 $ jj git fetch
 bookmark: trunk@origin [updated] tracked
 $ jj log --limit 3
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 │ @  znurnwmk steve@steveklabnik.com 2024-03-01 18:15:00.000 f853107d
 ├─╯  (empty) (no description set)
-@  povouosx steve@steveklabnik.com 2024-03-01 18:12:43.000 -06:00 f68d1623
+◆  povouosx steve@steveklabnik.com 2024-03-01 18:12:43 f68d1623
 │  remove goodbye message
 ~
 ```
@@ -141,9 +141,9 @@ Creating bookmark push-vmunwxsksqvk for revision vmunwxsksqvk
 Changes to push to origin:
   Add bookmark push-vmunwxsksqvk to 9410db49f9ba
 $ jj log
-@  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 push-vmunwxsksqvk 9410db49
+@  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk 9410db49
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```

--- a/src/sharing-code/tags.md
+++ b/src/sharing-code/tags.md
@@ -1,0 +1,135 @@
+# Tagging a release with `jj tag`
+
+We've seen that bookmarks move. That's the point of them: `trunk` follows our
+main line of development, and a pull request bookmark follows the tip of the
+pull request. Sometimes we want the opposite, though: a name for one exact
+commit. That's a tag.
+
+If you've used `git tag`, this will feel familiar. Let's mark the commit that
+`trunk` currently points at:
+
+```console
+$ jj tag set v1.0.0 -r trunk
+Created 1 tags pointing to ksrmwuon e202b67c trunk | Update Cargo.toml
+```
+
+We can see our tags with `jj tag list`:
+
+```console
+$ jj tag list
+v1.0.0: ksrmwuon e202b67c Update Cargo.toml
+```
+
+And tags show up in `jj log` alongside bookmarks:
+
+```console
+$ jj log --limit 3
+@  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk 752534be
+│  add a new function
+○  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
+│  add a comment to main
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk v1.0.0 e202b67c
+│  Update Cargo.toml
+```
+
+## Tags don't move
+
+Here's the difference from a bookmark. Let's try to point `v1.0.0` somewhere
+else:
+
+```console
+$ jj tag set v1.0.0 -r @
+Error: Refusing to move tag: v1.0.0
+Hint: Use --allow-move to update existing tags.
+```
+
+`jj bookmark set` moves a bookmark without complaint, because that's what
+bookmarks are for. A tag is supposed to be a fixed point, so `jj` makes you say
+you meant it:
+
+```console
+$ jj tag set v1.0.0 -r @ --allow-move
+Moved 1 tags to msmntwvo 752534be add a new function
+```
+
+Most of the time, you shouldn't need that flag. If you find yourself reaching
+for it a lot, you probably wanted a bookmark.
+
+## Tags make history immutable
+
+Remember immutability from the last couple of chapters? Tags are part of the
+immutable set, right alongside `trunk()`. So tagging a commit freezes it and
+everything behind it:
+
+```console
+$ jj tag set v2.0.0 -r @-
+Created 1 tags pointing to vmunwxsk f6f7dce9 add a comment to main
+$ jj describe @- -m "second thoughts about this one"
+Error: Commit f6f7dce9d9a1 is immutable
+Hint: Could not modify commit: vmunwxsk f6f7dce9 add a comment to main
+Hint: Immutable commits are used to protect shared history.
+```
+
+This can be surprising. If we tag a commit in the middle of work we're still
+rearranging, `jj` won't let us rearrange it any more. That makes sense: we told
+`jj` this commit was a fixed point. If we tagged it by mistake, `jj tag delete`
+puts things back:
+
+```console
+$ jj tag delete v2.0.0
+Deleted 1 tags.
+```
+
+And if the commit you tag happens to be the one your working copy is sitting
+on, you'll see the same shuffle we saw when we pushed `trunk`:
+
+```console
+$ jj tag set v1.1.0 -r @
+Created 1 tags pointing to msmntwvo 752534be add a new function
+Warning: The working-copy commit became immutable; a new commit has been created on top of it.
+Working copy  (@) now at: yqrwvxnn 90f315f0 (empty) (no description set)
+Parent commit (@-)      : msmntwvo 752534be add a new function
+```
+
+Same reason as before: you can't keep editing a commit you're no longer allowed
+to edit, so `jj` moves you up to a fresh one.
+
+## Pushing tags
+
+Tags are local until you push them, and this works exactly like bookmarks did:
+a tag the remote has never heard of doesn't get created by a bare `jj git push`.
+You name it with `-t`, the way you named a new bookmark with `-b`:
+
+```console
+$ jj git push -t v1.0.0
+Changes to push to origin:
+  tag: v1.0.0 [add to e202b67c1f0a]
+```
+
+Once the remote has it, though, a bare push will keep it up to date along with
+everything else:
+
+```console
+$ jj git push
+Changes to push to origin:
+  bookmark: trunk [move forward from e202b67c1f0a to 752534beb39f]
+  tag: v1.0.0 [move forward from e202b67c1f0a to 752534beb39f]
+```
+
+`jj` also distinguishes the local tag from the remote one, the same way it does
+for bookmarks. An asterisk means they've drifted apart, and `jj tag list` will
+tell you by how much:
+
+```console
+$ jj tag list
+v1.0.0: msmntwvo 752534be add a new function
+  @origin (behind by 2 commits): ksrmwuon e202b67c Update Cargo.toml
+```
+
+There is one limitation worth knowing: `jj tag set` creates *lightweight* tags.
+`jj` can read the annotated tags that `git tag -a` produces, but it can't create
+them. If your project needs an annotated or signed tag for a release, make it
+through your hosting service or with `git` directly.
+
+Deleting works like bookmarks too: `jj tag delete` marks the deletion locally.
+We can push tracked tag deletions explicitly with `jj git push --deleted`.

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -60,7 +60,7 @@ Remember, `jj new` won't move any branches, and so if we push, nothing happens:
 
 ```console
 $ jj git push
-Warning: No bookmarks found in the default push revset: remote_bookmarks(remote=origin)..@
+Warning: No bookmarks/tags found in the default push revset: remote_bookmarks(remote=origin)..@
 Nothing changed.
 ```
 
@@ -71,7 +71,7 @@ $ jj bookmark set push-vmunwxsksqvk
 Moved 1 bookmarks to nzsvmmzl ad6b9b14 push-vmunwxsksqvk* | respond to feedback
 $ jj git push
 Changes to push to origin:
-  Move forward bookmark push-vmunwxsksqvk from 9410db49f9ba to ad6b9b149f88
+  bookmark: push-vmunwxsksqvk [move forward from 9410db49f9ba to ad6b9b149f88]
 ```
 
 ![a screenshot of github, showing the new commit below our review](../images/new-pr-commit.png)
@@ -170,7 +170,7 @@ already been "rebased" in a sense. So we can just push:
 ```console
 > jj git push
 Changes to push to origin:
-  Move sideways bookmark push-vmunwxsksqvk from ad6b9b149f88 to 586ea9fd213f
+  bookmark: push-vmunwxsksqvk [move sideways from ad6b9b149f88 to 586ea9fd213f]
 ```
 
 We can see that reflected on GitHub:
@@ -239,7 +239,7 @@ Let's update our branch and push:
 Moved 1 bookmarks to msmntwvo 8f7dcd91 push-vmunwxsksqvk* | add a new function
 > jj git push
 Changes to push to origin:
-  Move sideways bookmark push-vmunwxsksqvk from 586ea9fd213f to 8f7dcd91ecbf
+  bookmark: push-vmunwxsksqvk [move sideways from 586ea9fd213f to 8f7dcd91ecbf]
 ```
 
 We now have two changes again. So what happens when we address our review? Well,
@@ -301,7 +301,7 @@ Parent commit (@-)      : vmunwxsk f6f7dce9 add a comment to main
 Added 0 files, modified 1 files, removed 0 files
 $ jj git push
 Changes to push to origin:
-  Move sideways bookmark push-vmunwxsksqvk from 8f7dcd91ecbf to 752534beb39f
+  bookmark: push-vmunwxsksqvk [move sideways from 8f7dcd91ecbf to 752534beb39f]
 ```
 
 And now we're good! Just that easy. If we didn't want to move `@`, we could have

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -47,11 +47,11 @@ Our change is ready, but one thing is missing:
 
 ```console
 $ jj log
-@  nzsvmmzl steve@steveklabnik.com 2024-03-02 09:22:40.000 -06:00 ad6b9b14
+@  nzsvmmzl steve@steveklabnik.com 2024-03-02 09:22:40 ad6b9b14
 │  respond to feedback
-◉  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 push-vmunwxsksqvk 9410db49
+○  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk 9410db49
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -113,11 +113,11 @@ First, we have to undo what we just did. Here's where we are:
 
 ```console
 > jj log
-@  nzsvmmzl steve@steveklabnik.com 2024-03-02 09:22:40.000 -06:00 push-vmunwxsksqvk ad6b9b14
+@  nzsvmmzl steve@steveklabnik.com 2024-03-02 09:22:40 push-vmunwxsksqvk ad6b9b14
 │  respond to feedback
-◉  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 9410db49
+○  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 9410db49
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -134,9 +134,9 @@ Added 0 files, modified 1 files, removed 0 files
 $ jj abandon nzsvmmzl
 Abandoned commit nzsvmmzl ad6b9b14 push-vmunwxsksqvk@origin | respond to feedback
 $ jj log
-@  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30.000 -06:00 push-vmunwxsksqvk* 9410db49
+@  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk* 9410db49
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 ```
@@ -287,11 +287,11 @@ push:
 
 ```console
 $ jj log
-◉  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 push-vmunwxsksqvk* 752534be
+○  msmntwvo steve@steveklabnik.com 2024-03-02 11:47:08 push-vmunwxsksqvk* 752534be
 │  add a new function
-@  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08.000 -06:00 f6f7dce9
+@  vmunwxsk steve@steveklabnik.com 2024-03-02 11:47:08 f6f7dce9
 │  add a comment to main
-◉  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35.000 -06:00 trunk e202b67c
+◆  ksrmwuon steve@steveklabnik.com 2024-03-01 23:10:35 trunk e202b67c
 │  Update Cargo.toml
 ~
 $ jj next --edit

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -274,7 +274,6 @@ And check our work:
 
 ```console
 $ jj st
- jj st
 Rebased 1 descendant commits onto updated working copy.
 Working copy changes:
 M src/main.rs

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -21,8 +21,8 @@ Let's create a new change:
 
 ```console
 $ jj new -m "respond to feedback"
-Working copy now at: nzsvmmzl 3b663200 (empty) respond to feedback
-Parent commit      : vmunwxsk 9410db49 push-vmunwxsksqvk | add a comment to main
+Working copy  (@) now at: nzsvmmzl 3b663200 (empty) respond to feedback
+Parent commit (@-)      : vmunwxsk 9410db49 push-vmunwxsksqvk | add a comment to main
 ```
 
 And change the text of the comment in `src/main.rs`:
@@ -128,8 +128,8 @@ So let's move the branch backwards, then abandon our new change:
 $ jj bookmark set push-vmunwxsksqvk -r @- --allow-backwards
 Moved 1 bookmarks to vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment to main
 $ jj edit vmunwxsk
-Working copy now at: vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment to main
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment to main
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 $ jj abandon nzsvmmzl
 Abandoned commit nzsvmmzl ad6b9b14 push-vmunwxsksqvk@origin | respond to feedback
@@ -208,8 +208,8 @@ new`:
 
 ```output
 $  jj new -m "add a new function"
-Working copy now at: msmntwvo baaa23e8 (empty) add a new function
-Parent commit      : vmunwxsk 6da57c93 push-vmunwxsksqvk* | add a comment to main
+Working copy  (@) now at: msmntwvo baaa23e8 (empty) add a new function
+Parent commit (@-)      : vmunwxsk 6da57c93 push-vmunwxsksqvk* | add a comment to main
 ```
 
 And then add some new functionality:
@@ -246,8 +246,8 @@ since we're okay with rebasing, we can just edit that commit directly:
 
 ```console
 $ jj edit vmunwxsk
-Working copy now at: vmunwxsk 6da57c93 add a comment to main
-Parent commit      : ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) now at: vmunwxsk 6da57c93 add a comment to main
+Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 ```
 
@@ -277,8 +277,8 @@ $ jj st
 Rebased 1 descendant commits onto updated working copy
 Working copy changes:
 M src/main.rs
-Working copy : vmunwxsk f6f7dce9 add a comment to main
-Parent commit: ksrmwuon e202b67c trunk | Update Cargo.toml
+Working copy  (@) : vmunwxsk f6f7dce9 add a comment to main
+Parent commit (@-): ksrmwuon e202b67c trunk | Update Cargo.toml
 ```
 
 There's that automatic rebase again! We don't need to do anything with our
@@ -295,8 +295,8 @@ $ jj log
 │  Update Cargo.toml
 ~
 $ jj next --edit
-Working copy now at: msmntwvo 752534be push-vmunwxsksqvk* | add a new function
-Parent commit      : vmunwxsk f6f7dce9 add a comment to main
+Working copy  (@) now at: msmntwvo 752534be push-vmunwxsksqvk* | add a new function
+Parent commit (@-)      : vmunwxsk f6f7dce9 add a comment to main
 Added 0 files, modified 1 files, removed 0 files
 $ jj git push
 Changes to push to origin:

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -276,7 +276,7 @@ $ jj st
  jj st
 Rebased 1 descendant commits onto updated working copy
 Working copy changes:
-M src\main.rs
+M src/main.rs
 Working copy : vmunwxsk f6f7dce9 add a comment to main
 Parent commit: ksrmwuon e202b67c trunk | Update Cargo.toml
 ```

--- a/src/sharing-code/updating-prs.md
+++ b/src/sharing-code/updating-prs.md
@@ -132,7 +132,8 @@ Working copy  (@) now at: vmunwxsk 9410db49 push-vmunwxsksqvk* | add a comment t
 Parent commit (@-)      : ksrmwuon e202b67c trunk | Update Cargo.toml
 Added 0 files, modified 1 files, removed 0 files
 $ jj abandon nzsvmmzl
-Abandoned commit nzsvmmzl ad6b9b14 push-vmunwxsksqvk@origin | respond to feedback
+Abandoned 1 commits:
+  nzsvmmzl ad6b9b14 push-vmunwxsksqvk@origin | respond to feedback
 $ jj log
 @  vmunwxsk steve@steveklabnik.com 2024-03-02 08:27:30 push-vmunwxsksqvk* 9410db49
 │  add a comment to main
@@ -274,7 +275,7 @@ And check our work:
 ```console
 $ jj st
  jj st
-Rebased 1 descendant commits onto updated working copy
+Rebased 1 descendant commits onto updated working copy.
 Working copy changes:
 M src/main.rs
 Working copy  (@) : vmunwxsk f6f7dce9 add a comment to main

--- a/src/sharing-code/updating-trunk.md
+++ b/src/sharing-code/updating-trunk.md
@@ -1,0 +1,184 @@
+# Updating trunk from upstream
+
+Everything so far has assumed the repository stands still while we work. In a
+real project, other people will merge things into `main`, and our work will
+eventually need to catch up. Let's see how to do that.
+
+## Getting the new commits
+
+`jj git fetch` pulls new commits and bookmark positions down from the remote:
+
+```console
+$ jj git fetch
+bookmark: main@origin [updated] tracked
+```
+
+Notice what it *didn't* do: nothing in our working copy moved, and no merge
+happened. Where `git pull` combines fetching with an integration step, `jj`
+keeps those two jobs separate. We can fetch first, inspect the result, and then
+choose how to move our work.
+
+Let's look at where things sit afterwards:
+
+```console
+$ jj log
+@  nxoupqvp steve@steveklabnik.com 2024-03-22 10:12:04 60d3e181
+│  more work
+○  tqmvurqz steve@steveklabnik.com 2024-03-22 10:12:04 my-feature d04bd54d
+│  my feature
+│ ◆  ztzvtupk steve@steveklabnik.com 2024-03-22 10:14:31 main 2fd78044
+├─╯  upstream commit
+◆  qoypmutx steve@steveklabnik.com 2024-03-22 09:58:12 23a248a4
+│  initial
+~
+```
+
+There's the drift, drawn out. `main` moved forward, our two changes are still
+sitting on the old commit, and the two lines have forked apart.
+
+The local `main` bookmark moved on its own, because it *tracks* `main@origin`
+and we hadn't touched it locally. This is the normal case, and it's why you
+rarely think about the local copy of trunk at all.
+
+Also notice the diamonds: `main` and the initial commit are immutable. The
+default *immutable heads* are
+`trunk() | tags() | untracked_remote_bookmarks()`, and those heads plus all
+their ancestors are immutable. A tracked remote bookmark for a pull request is
+deliberately not an immutable head, so pushed review branches can still be
+rewritten.
+
+## Moving your work onto it
+
+Now let's catch up. `jj rebase -b @ -o trunk()` takes the whole branch our
+working copy is on and puts it on trunk:
+
+```console
+$ jj rebase -b @ -o 'trunk()'
+Rebased 2 commits to destination.
+Working copy  (@) now at: nxoupqvp 355a63e0 more work
+Parent commit (@-)      : tqmvurqz 71ade80c my-feature | my feature
+Added 1 files, modified 0 files, removed 0 files
+```
+
+```console
+$ jj log
+@  nxoupqvp steve@steveklabnik.com 2024-03-22 10:16:02 355a63e0
+│  more work
+○  tqmvurqz steve@steveklabnik.com 2024-03-22 10:16:02 my-feature 71ade80c
+│  my feature
+◆  ztzvtupk steve@steveklabnik.com 2024-03-22 10:14:31 main 2fd78044
+│  upstream commit
+~
+```
+
+One line again. Both changes kept their change IDs — `nxoupqvp` and `tqmvurqz`
+are the same changes they were before — and got new commit IDs, because their
+contents now sit on a different parent. The bookmark came along for the ride.
+
+`jj rebase` takes two halves: which revisions move, and where they land.
+
+There are three flags we can use to choose what moves:
+
+* `-b` (branch) moves everything connected to the given revision that isn't
+  already an ancestor of the destination. This is the one you want for "catch my
+  work up to trunk".
+* `-s` (source) moves that revision and its descendants.
+* `-r` (revision) moves exactly one revision, and reparents its descendants onto
+  its old parent.
+
+`-o` (onto) chooses where they land, leaving the destination's existing
+descendants where they are. Its two siblings splice into a stack instead:
+`-A` inserts after the target and replants the target's descendants on top of
+the moved work, and `-B` inserts before it.
+
+`trunk()` is a revset function resolving to the main bookmark. `jj git clone`
+sets it up for you — you'll see `revset-aliases."trunk()" = "main@origin"` in the
+repository's config — so it points at whatever the project actually calls its
+trunk, and you can write `trunk()` in scripts and aliases without caring.
+
+If the rebase produces conflicts, they get recorded in the rebased commits and
+you carry on, exactly as in the conflicts chapter. Nothing stops halfway, and
+there's no `--continue` to remember.
+
+## Seeing what's yours
+
+The revset `trunk()..@` means "everything from trunk up to my working copy",
+which is a precise way of saying "my work":
+
+```console
+$ jj log -r 'trunk()..@'
+@  nxoupqvp steve@steveklabnik.com 2024-03-22 10:16:02 355a63e0
+│  more work
+○  tqmvurqz steve@steveklabnik.com 2024-03-22 10:16:02 my-feature 71ade80c
+│  my feature
+~
+```
+
+That one earns a place in your config as an alias. We'll do that in the
+customization section.
+
+## When trunk has diverged
+
+Sometimes we commit directly onto `main` locally, and upstream moves too. Now
+both ends of the bookmark have moved, and `jj` won't guess which one we meant:
+
+```console
+$ jj git fetch
+bookmark: main@origin [updated] tracked
+
+$ jj log
+@  oqtwrqnv steve@steveklabnik.com 2024-03-22 10:20:11 main?? main@git 914cd522
+│  (empty) local commit on main
+│ ◆  quvlnmky steve@steveklabnik.com 2024-03-22 10:20:37 main?? main@origin edd53bde
+├─╯  upstream commit 2
+```
+
+The `??` marks a *conflicted bookmark*: one name, two candidate positions. It's
+not a file conflict, and it doesn't block you — but a bookmark pointing at two
+commits can't be pushed anywhere sensible.
+
+`jj bookmark list` lays out the disagreement:
+
+```console
+$ jj bookmark list
+main (conflicted):
+  - ztzvtupk 2fd78044 upstream commit 1
+  + oqtwrqnv 914cd522 (empty) local commit on main
+  + quvlnmky edd53bde upstream commit 2
+  @git (behind by 1 commits): oqtwrqnv 914cd522 (empty) local commit on main
+  @origin (behind by 1 commits): quvlnmky edd53bde upstream commit 2
+my-feature: tqmvurqz 71ade80c my feature
+Hint: Some bookmarks have conflicts. Use `jj bookmark set <name> -r <rev>` to resolve.
+```
+
+The `-` line is the common ancestor the two sides started from, and the `+`
+lines are the two positions. Fix it the same way you'd fix the drift: put your
+local commit on top of the remote one.
+
+```console
+$ jj rebase -r oqtwrqnv -o main@origin
+Rebased 1 commits to destination.
+Working copy  (@) now at: oqtwrqnv 07effb17 main* | (empty) local commit on main
+Parent commit (@-)      : quvlnmky edd53bde main@origin | upstream commit 2
+```
+
+```console
+$ jj bookmark list
+main: oqtwrqnv 07effb17 (empty) local commit on main
+  @origin (behind by 1 commits): quvlnmky edd53bde upstream commit 2
+```
+
+The `??` is gone. The bookmark followed the commit it was pointing at, and once
+that commit sat on top of `main@origin` there was nothing left to disagree
+about. The `*` in `main*` means the local bookmark is ahead of the remote — the
+push you'd expect to make next.
+
+If you'd rather throw the local side away than keep it,
+`jj bookmark set main -r main@origin` names the winner directly. Your commit
+isn't lost; it's still in the log, just no longer wearing the bookmark.
+
+## The habit
+
+I like to fetch and rebase onto trunk regularly. The rebase is cheap, it never
+interrupts us, and any conflicts are recorded rather than blocking the command.
+That keeps catching up a small part of the ordinary workflow.


### PR DESCRIPTION
Further to the cosmetic changes in https://github.com/steveklabnik/jujutsu-tutorial/pull/113

I've used Codex Sol here to expand the tutorial, and add some missing chapters. Don't know how you feel about more expansive use of AI like this, but I've tried to keep the tone consistent with your original work.

Everything should be confirmed against a test repo for jj version 0.44, August 20th 2026. I've using the Homebrew release on Mac.

Intended to be merged on top of https://github.com/steveklabnik/jujutsu-tutorial/pull/113